### PR TITLE
Add element & evaluate tests

### DIFF
--- a/lib/browser/_asserters.js
+++ b/lib/browser/_asserters.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var util = require('util');
+
+var assert = require('assertive');
+var Bluebird = require('bluebird');
+var _ = require('lodash');
+var wd = require('wd');
+
+var matchers = require('./_matchers');
+
+var Asserter = wd.Asserter;
+
+function AssertionError(message) {
+  Error.call(this, arguments);
+  this.message = message;
+  this.retriable = true;
+
+  Error.captureStackTrace(this, AssertionError);
+}
+util.inherits(AssertionError, Error);
+
+exports.isDisplayed = function assertIsDisplayed(expected, selector) {
+  return new Asserter(function testTarget(target) {
+    if (!target) {
+      if (!expected) {
+        return null; // silently ignore if we want it not to be displayed anyhow
+      }
+      throw new AssertionError('Element not found for selector: ' + selector);
+    }
+
+    return target.isDisplayed().then(function compareTo(actual) {
+      if (actual !== expected) {
+        throw new AssertionError(
+          'Element should ' + (expected ? '' : 'not ') +
+          'be displayed for selector: ' + selector
+        );
+      }
+    });
+  });
+};
+
+exports.exists = function assertExists(expected, selector) {
+  return new Asserter(function testTarget(target) {
+    if (!!target !== expected) {
+      throw new AssertionError(
+        'Element should ' + (expected ? '' : 'not ') +
+        'exist for selector: ' + selector
+      );
+    }
+  });
+};
+
+function stringify(value) {
+  if (_.isRegExp(value)) {
+    return '' + value;
+  }
+  return JSON.stringify(value);
+}
+
+function secondToLowerCase(first, second) {
+  return second.toLowerCase();
+}
+
+function getterToPropName(propName) {
+  return propName.replace(/^get([A-Z])/, secondToLowerCase);
+}
+
+exports.fuzzyString = function assertFuzzyString(extract, expected, shouldMatch, selector) {
+  var propName;
+  if (typeof extract === 'string') {
+    propName = getterToPropName(extract);
+    extract = _.method(extract);
+  } else if (typeof extract === 'function') {
+    propName = getterToPropName(extract.name);
+  } else {
+    throw new Error('Invalid extract: ' + extract);
+  }
+  var doc = selector + ' should ' + (shouldMatch ? '' : 'not ') + 'have ' + propName;
+
+  return new Asserter(function testTarget(target) {
+    return Bluebird.resolve(target).then(extract).then(function compareTo(actual) {
+      assert.hasType(String, actual);
+      var match = matchers.fuzzyString(expected, actual);
+      if (match !== shouldMatch) {
+        var message = [
+          doc,
+          '- needle: ' + stringify(expected),
+          '- ' + propName + ': ' + stringify(actual),
+        ].join('\n');
+        throw new AssertionError(message);
+      }
+    });
+  });
+};

--- a/lib/browser/_asserters.js
+++ b/lib/browser/_asserters.js
@@ -11,9 +11,9 @@ var matchers = require('./_matchers');
 
 var Asserter = wd.Asserter;
 
-function AssertionError(message) {
-  Error.call(this, arguments);
-  this.message = message;
+function AssertionError() {
+  Error.call(this);
+  this.message = util.format.apply(util, arguments);
   this.retriable = true;
 
   Error.captureStackTrace(this, AssertionError);
@@ -23,18 +23,13 @@ util.inherits(AssertionError, Error);
 exports.isDisplayed = function assertIsDisplayed(expected, selector) {
   return new Asserter(function testTarget(target) {
     if (!target) {
-      if (!expected) {
-        return null; // silently ignore if we want it not to be displayed anyhow
-      }
       throw new AssertionError('Element not found for selector: ' + selector);
     }
 
     return target.isDisplayed().then(function compareTo(actual) {
       if (actual !== expected) {
-        throw new AssertionError(
-          'Element should ' + (expected ? '' : 'not ') +
-          'be displayed for selector: ' + selector
-        );
+        throw new AssertionError('Element %j should%s be displayed',
+          selector, (expected ? '' : 'n\'t'));
       }
     });
   });
@@ -43,10 +38,8 @@ exports.isDisplayed = function assertIsDisplayed(expected, selector) {
 exports.exists = function assertExists(expected, selector) {
   return new Asserter(function testTarget(target) {
     if (!!target !== expected) {
-      throw new AssertionError(
-        'Element should ' + (expected ? '' : 'not ') +
-        'exist for selector: ' + selector
-      );
+      throw new AssertionError('Element %j should%s exist',
+        selector, (expected ? '' : 'n\'t'));
     }
   });
 };

--- a/lib/browser/_matchers.js
+++ b/lib/browser/_matchers.js
@@ -16,6 +16,19 @@ function string(expected, actual) {
 }
 exports.string = string;
 
+function fuzzyString(expected, actual) {
+  debug('fuzzyString: %s === %s', expected, actual);
+  if (expected === '') {
+    return actual === '';
+  } else if (typeof expected === 'string') {
+    return actual.indexOf(expected) !== -1;
+  } else if (_.isRegExp(expected)) {
+    return expected.test(actual);
+  }
+  throw new Error('Invalid assertion: ' + expected);
+}
+exports.fuzzyString = fuzzyString;
+
 function stringUnlessNull(expected, actual) {
   if (expected === null || expected === undefined) {
     debug('skipping: %s === %s', expected, actual);

--- a/lib/browser/cookie.js
+++ b/lib/browser/cookie.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var assert = require('assertive');
 var Bluebird = require('bluebird');
 var _ = require('lodash');
 
@@ -37,6 +38,13 @@ exports._getTestiumCookieField = function _getTestiumCookieField(name) {
 
 exports.getStatusCode = function getStatusCode() {
   return this._getTestiumCookieField('statusCode');
+};
+
+exports.assertStatusCode = function assertStatusCode(expectedStatus) {
+  return this.getStatusCode()
+    .then(function compareTo(actualStatus) {
+      assert.equal('statusCode', expectedStatus, actualStatus);
+    });
 };
 
 exports.getHeaders = function getHeaders() {

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -1,6 +1,9 @@
 'use strict';
 
 var assert = require('assertive');
+var _ = require('lodash');
+
+var asserters = require('./_asserters');
 
 // var STALE_MESSAGE = /stale element reference/;
 
@@ -51,9 +54,17 @@ exports.getElementOrNull = function getElementOrNull(selector) {
 };
 
 exports.getElement = function getElement(selector) {
-  var element = this.elementByCssSelectorOrNull(selector);
-  assert.truthy('Element not found at selector: ' + selector, element);
-  return element;
+  return this.elementByCssSelectorOrNull(selector)
+    .then(function rejectNullElement(element) {
+      if (element === null) {
+        throw new Error('Element not found for selector: ' + selector);
+      }
+      return element;
+    });
+};
+
+exports.getElements = function getElements(selector) {
+  return this.elementsByCssSelector(selector);
 };
 
 // exports.waitForElementVisible = function waitForElementVisible(selector, timeout) {
@@ -65,8 +76,7 @@ exports.getElement = function getElement(selector) {
 // };
 
 // exports.waitForElementExist = function waitForElementExist(selector, timeout) {
-//   return this._waitForElement(selector,
-//     elementDoesExistPredicate, elementDoesExistFailure, timeout);
+//   return this._waitForElement(selector, asserters.exists(selector, true), timeout);
 // };
 
 // exports.waitForElementNotExist = function waitForElementNotExist(selector, timeout) {
@@ -76,28 +86,6 @@ exports.getElement = function getElement(selector) {
 
 exports.clickOn = function clickOn(selector) {
   return this.getElement(selector).click();
-};
-
-exports.assert = function _assert(asserter) {
-  return asserter.assert(this);
-};
-
-exports.assertElement = function assertElement(selector, asserter) {
-  return asserter.assert(this);
-};
-
-exports.assertElementExists = function assertElementExists(selector) {
-  return this.getElementOrNull(selector)
-    .then(function checkElement(element) {
-      assert.truthy('Element not found for selector: ' + selector, element);
-    });
-};
-
-exports.assertElementDoesntExist = function assertElementDoesntExist(selector) {
-  return this.getElementOrNull(selector)
-    .then(function checkElement(element) {
-      assert.falsey('Element found for selector: ' + selector, element);
-    });
 };
 
 // function tryFindElement(self, selector, predicate, untilTime) {
@@ -138,3 +126,65 @@ exports.assertElementDoesntExist = function assertElementDoesntExist(selector) {
 
 //   return foundElement;
 // };
+
+exports.assert = function _assert(asserter) {
+  return asserter.assert(this);
+};
+
+exports.assertElement = function assertElement(selector, asserter) {
+  assert.hasType('selector should be a string', String, selector);
+  var element = this.elementsByCssSelector(selector)
+    .then(function ensureUnique(elements) {
+      switch (elements.length) {
+      case 0:
+        throw new Error('Element not found for selector: ' + selector);
+
+      case 1:
+        return elements[0];
+
+      default:
+        throw new Error(
+          'Selector .message has 3 hits on the page, assertions require unique elements');
+      }
+    });
+  return element.then(asserter.assert).then(_.constant(element));
+};
+
+exports.assertElementIsDisplayed = function assertElementIsDisplayed(selector) {
+  return this.assertElement(selector, asserters.isDisplayed(true, selector));
+};
+
+exports.assertElementNotDisplayed = function assertElementNotDisplayed(selector) {
+  return this.elementByCssSelectorOrNull(selector)
+    .then(asserters.isDisplayed(false, selector).assert);
+};
+
+exports.assertElementExists = function assertElementExists(selector) {
+  return this.elementByCssSelectorOrNull(selector)
+    .then(asserters.exists(true, selector).assert);
+};
+
+exports.assertElementDoesntExist = function assertElementDoesntExist(selector) {
+  return this.elementByCssSelectorOrNull(selector)
+    .then(asserters.exists(false, selector).assert);
+};
+
+exports.assertElementHasText = function assertElementHasText(selector, textOrRegExp) {
+  return this.assertElement(selector,
+    asserters.fuzzyString('text', textOrRegExp, true, selector));
+};
+
+exports.assertElementLacksText = function assertElementLacksText(selector, textOrRegExp) {
+  return this.assertElement(selector,
+    asserters.fuzzyString('text', textOrRegExp, false, selector));
+};
+
+exports.assertElementHasValue = function assertElementHasValue(selector, textOrRegExp) {
+  return this.assertElement(selector,
+    asserters.fuzzyString('getValue', textOrRegExp, true, selector));
+};
+
+exports.assertElementLacksValue = function assertElementLacksValue(selector, textOrRegExp) {
+  return this.assertElement(selector,
+    asserters.fuzzyString('getValue', textOrRegExp, false, selector));
+};

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -24,7 +24,9 @@ exports.getElements = function getElements(selector) {
   return this.elementsByCssSelector(selector);
 };
 
-// Our own version of wd's waitForElement. Because reasons.
+// Our own version of wd's waitForElement.
+// wd's version of waitFor* has the unfortunate habit of generating really
+// unhelpful error messages.
 function _waitForElement(browser, selector, asserter, timeout, pollFreq) {
   /* eslint no-use-before-define:0 */
   timeout = timeout || 2000;

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -6,50 +6,6 @@ var _ = require('lodash');
 
 var asserters = require('./_asserters');
 
-// var STALE_MESSAGE = /stale element reference/;
-
-// var NOT_FOUND_MESSAGE = new RegExp([
-//   'Unable to locate element', // firefox message
-//   'Unable to find element', // phantomjs message
-//   'no such element', // chrome message
-// ].join('|'));
-
-// function visiblePredicate(shouldBeVisible, element) {
-//   return element && element.isVisible() === shouldBeVisible;
-// }
-
-// function visibleFailure(shouldBeVisible, selector, timeout) {
-//   throw new Error(util.format('Timeout (%dms) waiting for element (%s) to %sbe visible.',
-//     timeout, selector, shouldBeVisible ? '' : 'not '));
-// }
-
-// // Curry some functions for later use
-// var isVisiblePredicate = _.partial(visiblePredicate, true);
-// var isntVisiblePredicate = _.partial(visiblePredicate, false);
-
-// var isVisibleFailure = _.partial(visibleFailure, true);
-// var isntVisibleFailure = _.partial(visibleFailure, false);
-
-// function elementExistsPredicate(shouldBeVisible, element) {
-//   return !!element === shouldBeVisible;
-// }
-
-// function elementExistsFailure(shouldBeVisible, selector, timeout) {
-//   throw new Error(util.format('Timeout (%dms) waiting for element (%s) %sto exist in page.',
-//     timeout, selector, shouldBeVisible ? '' : 'not '));
-// }
-
-// var elementDoesExistPredicate = _.partial(elementExistsPredicate, true);
-// var elementDoesNotExistPredicate = _.partial(elementExistsPredicate, false);
-
-// var elementDoesExistFailure = _.partial(elementExistsFailure, true);
-// var elementDoesNotExistFailure = _.partial(elementExistsFailure, false);
-
-// exports._forwarded = [
-//   // TODO: port type assertion for selector to webdriver-http-sync
-//   'getElements',
-// ];
-
 exports.getElementOrNull = function getElementOrNull(selector) {
   return this.elementByCssSelectorOrNull(selector);
 };
@@ -117,45 +73,6 @@ exports.waitForElementNotExist = function waitForElementNotExist(selector, timeo
 exports.clickOn = function clickOn(selector) {
   return this.getElement(selector).click();
 };
-
-// function tryFindElement(self, selector, predicate, untilTime) {
-//   var element;
-
-//   while (Date.now() < untilTime) {
-//     element = self.getElementWithoutError(selector);
-
-//     try {
-//       if (predicate(element)) {
-//         return element;
-//       }
-//     } catch (exception) {
-//       // Occasionally webdriver throws an error about the element reference being
-//       // stale.  Let's handle that case as the element doesn't yet exist. All
-//       // other errors are re thrown.
-//       if (!STALE_MESSAGE.test(exception.toString())) {
-//         throw exception;
-//       }
-//     }
-//   }
-//   return false;
-// }
-
-// // Where predicate takes a single parameter which is an element (or null) and
-// // returns true when the wait is over
-// exports._waitForElement = function _waitForElement(selector, predicate, failure, timeout) {
-//   assert.hasType('`selector` as to be a String', String, selector);
-//   timeout = timeout || 3000;
-
-//   this.driver.setElementTimeout(timeout);
-//   var foundElement = tryFindElement(this, selector, predicate, Date.now() + timeout);
-//   this.driver.setElementTimeout(0);
-
-//   if (foundElement === false) {
-//     return failure(selector, timeout);
-//   }
-
-//   return foundElement;
-// };
 
 exports.assert = function _assert(asserter) {
   return asserter.assert(this);

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -1,0 +1,140 @@
+'use strict';
+
+var assert = require('assertive');
+
+// var STALE_MESSAGE = /stale element reference/;
+
+// var NOT_FOUND_MESSAGE = new RegExp([
+//   'Unable to locate element', // firefox message
+//   'Unable to find element', // phantomjs message
+//   'no such element', // chrome message
+// ].join('|'));
+
+// function visiblePredicate(shouldBeVisible, element) {
+//   return element && element.isVisible() === shouldBeVisible;
+// }
+
+// function visibleFailure(shouldBeVisible, selector, timeout) {
+//   throw new Error(util.format('Timeout (%dms) waiting for element (%s) to %sbe visible.',
+//     timeout, selector, shouldBeVisible ? '' : 'not '));
+// }
+
+// // Curry some functions for later use
+// var isVisiblePredicate = _.partial(visiblePredicate, true);
+// var isntVisiblePredicate = _.partial(visiblePredicate, false);
+
+// var isVisibleFailure = _.partial(visibleFailure, true);
+// var isntVisibleFailure = _.partial(visibleFailure, false);
+
+// function elementExistsPredicate(shouldBeVisible, element) {
+//   return !!element === shouldBeVisible;
+// }
+
+// function elementExistsFailure(shouldBeVisible, selector, timeout) {
+//   throw new Error(util.format('Timeout (%dms) waiting for element (%s) %sto exist in page.',
+//     timeout, selector, shouldBeVisible ? '' : 'not '));
+// }
+
+// var elementDoesExistPredicate = _.partial(elementExistsPredicate, true);
+// var elementDoesNotExistPredicate = _.partial(elementExistsPredicate, false);
+
+// var elementDoesExistFailure = _.partial(elementExistsFailure, true);
+// var elementDoesNotExistFailure = _.partial(elementExistsFailure, false);
+
+// exports._forwarded = [
+//   // TODO: port type assertion for selector to webdriver-http-sync
+//   'getElements',
+// ];
+
+exports.getElementOrNull = function getElementOrNull(selector) {
+  return this.elementByCssSelectorOrNull(selector);
+};
+
+exports.getElement = function getElement(selector) {
+  var element = this.elementByCssSelectorOrNull(selector);
+  assert.truthy('Element not found at selector: ' + selector, element);
+  return element;
+};
+
+// exports.waitForElementVisible = function waitForElementVisible(selector, timeout) {
+//   return this._waitForElement(selector, isVisiblePredicate, isVisibleFailure, timeout);
+// };
+
+// exports.waitForElementNotVisible = function waitForElementNotVisible(selector, timeout) {
+//   return this._waitForElement(selector, isntVisiblePredicate, isntVisibleFailure, timeout);
+// };
+
+// exports.waitForElementExist = function waitForElementExist(selector, timeout) {
+//   return this._waitForElement(selector,
+//     elementDoesExistPredicate, elementDoesExistFailure, timeout);
+// };
+
+// exports.waitForElementNotExist = function waitForElementNotExist(selector, timeout) {
+//   return this._waitForElement(selector,
+//     elementDoesNotExistPredicate, elementDoesNotExistFailure, timeout);
+// };
+
+exports.clickOn = function clickOn(selector) {
+  return this.getElement(selector).click();
+};
+
+exports.assert = function _assert(asserter) {
+  return asserter.assert(this);
+};
+
+exports.assertElement = function assertElement(selector, asserter) {
+  return asserter.assert(this);
+};
+
+exports.assertElementExists = function assertElementExists(selector) {
+  return this.getElementOrNull(selector)
+    .then(function checkElement(element) {
+      assert.truthy('Element not found for selector: ' + selector, element);
+    });
+};
+
+exports.assertElementDoesntExist = function assertElementDoesntExist(selector) {
+  return this.getElementOrNull(selector)
+    .then(function checkElement(element) {
+      assert.falsey('Element found for selector: ' + selector, element);
+    });
+};
+
+// function tryFindElement(self, selector, predicate, untilTime) {
+//   var element;
+
+//   while (Date.now() < untilTime) {
+//     element = self.getElementWithoutError(selector);
+
+//     try {
+//       if (predicate(element)) {
+//         return element;
+//       }
+//     } catch (exception) {
+//       // Occasionally webdriver throws an error about the element reference being
+//       // stale.  Let's handle that case as the element doesn't yet exist. All
+//       // other errors are re thrown.
+//       if (!STALE_MESSAGE.test(exception.toString())) {
+//         throw exception;
+//       }
+//     }
+//   }
+//   return false;
+// }
+
+// // Where predicate takes a single parameter which is an element (or null) and
+// // returns true when the wait is over
+// exports._waitForElement = function _waitForElement(selector, predicate, failure, timeout) {
+//   assert.hasType('`selector` as to be a String', String, selector);
+//   timeout = timeout || 3000;
+
+//   this.driver.setElementTimeout(timeout);
+//   var foundElement = tryFindElement(this, selector, predicate, Date.now() + timeout);
+//   this.driver.setElementTimeout(0);
+
+//   if (foundElement === false) {
+//     return failure(selector, timeout);
+//   }
+
+//   return foundElement;
+// };

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -93,7 +93,8 @@ exports.assertElement = function assertElement(selector, asserter) {
 
       default:
         throw new Error(
-          'Selector .message has 3 hits on the page, assertions require unique elements');
+          'Selector ' + selector + ' has ' + elements.length +
+          ' hits on the page, assertions require unique elements');
       }
     });
   return element.then(asserter.assert).then(_.constant(element));

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assertive');
+var Bluebird = require('bluebird');
 var _ = require('lodash');
 
 var asserters = require('./_asserters');
@@ -67,22 +68,51 @@ exports.getElements = function getElements(selector) {
   return this.elementsByCssSelector(selector);
 };
 
-// exports.waitForElementVisible = function waitForElementVisible(selector, timeout) {
-//   return this._waitForElement(selector, isVisiblePredicate, isVisibleFailure, timeout);
-// };
+// Our own version of wd's waitForElement. Because reasons.
+function _waitForElement(browser, selector, asserter, timeout, pollFreq) {
+  /* eslint no-use-before-define:0 */
+  timeout = timeout || 2000;
+  pollFreq = pollFreq || 50;
 
-// exports.waitForElementNotVisible = function waitForElementNotVisible(selector, timeout) {
-//   return this._waitForElement(selector, isntVisiblePredicate, isntVisibleFailure, timeout);
-// };
+  var endTime = Date.now() + timeout;
 
-// exports.waitForElementExist = function waitForElementExist(selector, timeout) {
-//   return this._waitForElement(selector, asserters.exists(selector, true), timeout);
-// };
+  function attempt() {
+    var element = browser.elementByCssSelectorOrNull(selector);
+    return element
+      .then(asserter.assert)
+      .catch(retry)
+      .then(_.constant(element));
+  }
 
-// exports.waitForElementNotExist = function waitForElementNotExist(selector, timeout) {
-//   return this._waitForElement(selector,
-//     elementDoesNotExistPredicate, elementDoesNotExistFailure, timeout);
-// };
+  function retry(error) {
+    if (!error.retriable) {
+      throw error;
+    }
+    if (Date.now() >= endTime) {
+      error.message = 'Timeout (' + timeout + 'ms): ' + error.message;
+      throw error;
+    }
+    return Bluebird.delay(pollFreq).then(attempt);
+  }
+
+  return attempt();
+}
+
+exports.waitForElementDisplayed = function waitForElementDisplayed(selector, timeout) {
+  return _waitForElement(this, selector, asserters.isDisplayed(true, selector), timeout);
+};
+
+exports.waitForElementNotDisplayed = function waitForElementNotDisplayed(selector, timeout) {
+  return _waitForElement(this, selector, asserters.isDisplayed(false, selector), timeout);
+};
+
+exports.waitForElementExist = function waitForElementExist(selector, timeout, pollFreq) {
+  return _waitForElement(this, selector, asserters.exists(true, selector), timeout, pollFreq);
+};
+
+exports.waitForElementNotExist = function waitForElementNotExist(selector, timeout, pollFreq) {
+  return _waitForElement(this, selector, asserters.exists(false, selector), timeout, pollFreq);
+};
 
 exports.clickOn = function clickOn(selector) {
   return this.getElement(selector).click();

--- a/lib/browser/evaluate.js
+++ b/lib/browser/evaluate.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var assert = require('assertive');
+var _ = require('lodash');
+
+exports.evaluate = function evaluate() {
+  var args = _.toArray(arguments);
+  var clientFunction = args.pop();
+
+  var invocation = 'evaluate(clientFunction) - requires (Function|String) clientFunction';
+  assert.truthy(invocation, clientFunction);
+
+  switch (typeof clientFunction) {
+  case 'function':
+    clientFunction =
+      'return (' + clientFunction + ').apply(this, ' + JSON.stringify(args) + ');';
+    /* falls through */
+  case 'string':
+    return this.execute(clientFunction);
+
+  default:
+    throw new Error(invocation);
+  }
+};

--- a/lib/element.js
+++ b/lib/element.js
@@ -1,0 +1,28 @@
+'use strict';
+
+exports.get = function get(name) {
+  return this.getAttribute(name);
+};
+
+function firstOrNull(elements) {
+  return elements[0] || null;
+}
+
+exports.getElementOrNull = function getElementOrNull(selector) {
+  return this.elementsByCssSelector(selector)
+    .then(firstOrNull);
+};
+
+exports.getElement = function getElement(selector) {
+  return this.elementsByCssSelector(selector)
+    .then(function rejectIfMissing(elements) {
+      if (elements.length === 0) {
+        throw new Error('Element not found for selector: ' + selector);
+      }
+      return elements[0];
+    });
+};
+
+exports.getElements = function getElements(selector) {
+  return this.elementsByCssSelector(selector);
+};

--- a/lib/element.js
+++ b/lib/element.js
@@ -17,7 +17,9 @@ exports.getElement = function getElement(selector) {
   return this.elementsByCssSelector(selector)
     .then(function rejectIfMissing(elements) {
       if (elements.length === 0) {
-        throw new Error('Element not found for selector: ' + selector);
+        throw new Error(
+          'Element ' + selector +
+          ' not found, use getElementOrNull if that\'s expected');
       }
       return elements[0];
     });

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -12,6 +12,8 @@ var defaultMethods = [
   require('./browser/navigation'),
 ];
 
+var defaultElementMethods = require('./element');
+
 function initDriver(testium) {
   function applyMethods(methods) {
     _.each(methods, function add(fn, name) {
@@ -20,6 +22,10 @@ function initDriver(testium) {
   }
 
   _.each(defaultMethods, applyMethods);
+
+  _.each(defaultElementMethods, function add(fn, name) {
+    wd.addElementPromiseChainMethod(name, fn);
+  });
 
   wd.addPromiseChainMethod('navigateTo', function navigateTo(url, options) {
     options = options || {};

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -7,6 +7,7 @@ var wd = require('wd');
 var defaultMethods = [
   require('./browser/console'),
   require('./browser/cookie'),
+  require('./browser/element'),
   require('./browser/navigation'),
 ];
 
@@ -43,6 +44,9 @@ function initDriver(testium) {
 
   var browser = driver.init({ browserName: testium.config.get('browser') });
   return browser
+    .sessionCapabilities().then(function storeCapabilities(capabilities) {
+      browser.capabilities = capabilities;
+    })
     .setPageSize({ height: 768, width: 1024 })
     .get(testium.getInitialUrl())
     .then(function addBrowser() {

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -8,6 +8,7 @@ var defaultMethods = [
   require('./browser/console'),
   require('./browser/cookie'),
   require('./browser/element'),
+  require('./browser/evaluate'),
   require('./browser/navigation'),
 ];
 

--- a/test/integration/console.test.js
+++ b/test/integration/console.test.js
@@ -13,7 +13,7 @@ describe('console', () => {
   // for console.logs differently.
   // Use at your own risk.
   it('can all be retrieved', async () => {
-    const { browserName } = await browser.sessionCapabilities();
+    const { browserName } = browser.capabilities;
     let logs;
 
     switch (browserName) {

--- a/test/integration/element.test.js
+++ b/test/integration/element.test.js
@@ -49,7 +49,7 @@ describe('element', () => {
 
     it('fails if element exists, but is not visible', async () => {
       const error = await assertRejects(browser.assertElementIsDisplayed('#hidden_thing'));
-      const expectedError = 'Element should be displayed for selector: #hidden_thing';
+      const expectedError = 'Element "#hidden_thing" should be displayed';
       assert.equal(expectedError, stripColors(error.message));
     });
 
@@ -58,12 +58,15 @@ describe('element', () => {
   });
 
   describe('assertElementNotDisplayed', () => {
-    it('succeeds if element does not exist', () =>
-      browser.assertElementNotDisplayed('.non-existing'));
+    it('fails if element does not exist', async () => {
+      const error = await assertRejects(browser.assertElementNotDisplayed('.non-existing'));
+      const expectedError = 'Element not found for selector: .non-existing';
+      assert.equal(expectedError, stripColors(error.message));
+    });
 
     it('fails if element exists, but is visible', async () => {
       const error = await assertRejects(browser.assertElementNotDisplayed('h1'));
-      const expectedError = 'Element should not be displayed for selector: h1';
+      const expectedError = 'Element "h1" shouldn\'t be displayed';
       assert.equal(expectedError, stripColors(error.message));
     });
 
@@ -74,7 +77,7 @@ describe('element', () => {
   describe('assertElementExists', () => {
     it('fails if element does not exist', async () => {
       const error = await assertRejects(browser.assertElementExists('.non-existing'));
-      const expectedError = 'Element should exist for selector: .non-existing';
+      const expectedError = 'Element ".non-existing" should exist';
       assert.equal(expectedError, stripColors(error.message));
     });
 
@@ -88,7 +91,7 @@ describe('element', () => {
 
     it('fails if element exists', async () => {
       const error = await assertRejects(browser.assertElementDoesntExist('h1'));
-      const expectedError = 'Element should not exist for selector: h1';
+      const expectedError = 'Element "h1" shouldn\'t exist';
       assert.equal(expectedError, stripColors(error.message));
     });
   });
@@ -162,7 +165,7 @@ describe('element', () => {
     });
   });
 
-  xdescribe('waitForElementExist', () => {
+  describe('waitForElementExist', () => {
     before(() => browser.navigateTo('/dynamic.html'));
 
     it('finds an element after waiting', async () => {
@@ -177,12 +180,12 @@ describe('element', () => {
 
     it('fails to find an element that never exists', async () => {
       const error = await assertRejects(browser.waitForElementExist('.does-not-exist', 10));
-      assert.equal('Timeout (10ms) waiting for element (.does-not-exist) to exist in page.',
+      assert.equal('Timeout (10ms): Element ".does-not-exist" should exist',
         error.message);
     });
   });
 
-  xdescribe('waitForElementNotExist', () => {
+  describe('waitForElementNotExist', () => {
     beforeEach(() => browser.navigateTo('/other-page.html'));
 
     function setupElement(keepAround) {
@@ -199,61 +202,60 @@ describe('element', () => {
       }, 300);
     }
 
-    it('succeeds once an element is gone', () => {
-      browser.evaluate(setupElement);
-      browser.assert.elementIsVisible('.remove_later');
-      browser.waitForElementNotExist('.remove_later');
+    it('succeeds once an element is gone', async () => {
+      await browser.evaluate(setupElement);
+      await browser.assertElementIsDisplayed('.remove_later');
+      await browser.waitForElementNotExist('.remove_later');
     });
 
-    it('fails when element still exists', () => {
-      browser.evaluate(/* keepAround = */ true, setupElement);
-      browser.assert.elementIsVisible('.remove_later');
-      const error = assert.throws(() =>
-        browser.waitForElementNotExist('.remove_later', 10));
-      assert.equal('Timeout (10ms) waiting for element (.remove_later) not to exist in page.',
+    it('fails when element still exists', async () => {
+      await browser.evaluate(/* keepAround = */ true, setupElement);
+      await browser.assertElementIsDisplayed('.remove_later');
+      const error = await assertRejects(browser.waitForElementNotExist('.remove_later', 10));
+      assert.equal('Timeout (10ms): Element ".remove_later" shouldn\'t exist',
         error.message);
     });
   });
 
-  xdescribe('waitForElementVisible', () => {
+  describe('waitForElementDisplayed', () => {
     before(() => browser.navigateTo('/dynamic.html'));
 
-    it('finds an element after waiting', () => {
-      browser.assert.elementNotVisible('.load_later');
-      browser.waitForElementVisible('.load_later');
+    it('finds an element after waiting', async () => {
+      await browser.assertElementNotDisplayed('.load_later');
+      await browser.waitForElementDisplayed('.load_later');
     });
 
-    it('fails to find a visible element within the timeout', () => {
-      const error = assert.throws(() =>
-        browser.waitForElementVisible('.load_never', 10));
-      assert.equal('Timeout (10ms) waiting for element (.load_never) to be visible.', error.message);
+    it('fails to find a visible element within the timeout', async () => {
+      const error = await assertRejects(browser.waitForElementDisplayed('.load_never', 10));
+      assert.equal('Timeout (10ms): Element ".load_never" should be displayed',
+        error.message);
     });
 
-    it('fails to find an element that never exists', () => {
-      const error = assert.throws(() =>
-        browser.waitForElementVisible('.does-not-exist', 10));
-      assert.equal('Timeout (10ms) waiting for element (.does-not-exist) to be visible.', error.message);
+    it('fails to find an element that never exists', async () => {
+      const error = await assertRejects(browser.waitForElementDisplayed('.does-not-exist', 10));
+      assert.equal('Timeout (10ms): Element not found for selector: .does-not-exist',
+        error.message);
     });
   });
 
-  xdescribe('waitForElementNotVisible', () => {
+  describe('waitForElementNotDisplayed', () => {
     before(() => browser.navigateTo('/dynamic.html'));
 
-    it('does not find an existing element after waiting for it to disappear', () => {
-      browser.assert.elementIsVisible('.hide_later');
-      browser.waitForElementNotVisible('.hide_later');
+    it('does not find an existing element after waiting for it to disappear', async () => {
+      await browser.assertElementIsDisplayed('.hide_later');
+      await browser.waitForElementNotDisplayed('.hide_later');
     });
 
-    it('fails to find a not-visible element within the timeout', () => {
-      const error = assert.throws(() =>
-        browser.waitForElementNotVisible('.hide_never', 10));
-      assert.equal('Timeout (10ms) waiting for element (.hide_never) to not be visible.', error.message);
+    it('fails to find a not-visible element within the timeout', async () => {
+      const error = await assertRejects(browser.waitForElementNotDisplayed('.hide_never', 10));
+      assert.equal('Timeout (10ms): Element ".hide_never" shouldn\'t be displayed',
+        error.message);
     });
 
-    it('fails to find an element that never exists', () => {
-      const error = assert.throws(() =>
-        browser.waitForElementNotVisible('.does-not-exist', 10));
-      assert.equal('Timeout (10ms) waiting for element (.does-not-exist) to not be visible.', error.message);
+    it('fails to find an element that never exists', async () => {
+      const error = await assertRejects(browser.waitForElementNotDisplayed('.does-not-exist', 10));
+      assert.equal('Timeout (10ms): Element not found for selector: .does-not-exist',
+        error.message);
     });
   });
 

--- a/test/integration/element.test.js
+++ b/test/integration/element.test.js
@@ -26,7 +26,7 @@ describe('element', () => {
     // returns a non-standard response from selenium;
     // let's make sure we can handle it properly
     const element = await browser.getElement('#checkbox');
-    const checked = await element.getAttribute('checked');
+    const checked = await element.get('checked');
     assert.equal('checked is null', null, checked);
   });
 
@@ -99,7 +99,7 @@ describe('element', () => {
   describe('elementHasText', () => {
     it('finds and returns a single element', async () => {
       const element = await browser.assertElementHasText('.only', 'only one here');
-      assert.equal('resolve the element\'s class', 'only', await element.getAttribute('class'));
+      assert.equal('resolve the element\'s class', 'only', await element.get('class'));
     });
 
     it('finds an element with the wrong text', async () => {
@@ -129,7 +129,7 @@ describe('element', () => {
   describe('elementLacksText', () => {
     it('asserts an element lacks some text, and returns the element', async () => {
       const element = await browser.assertElementLacksText('.only', 'this text not present');
-      assert.equal('resolve the element\'s class', 'only', await element.getAttribute('class'));
+      assert.equal('resolve the element\'s class', 'only', await element.get('class'));
     });
 
     it('finds an element incorrectly having some text', async () => {
@@ -143,7 +143,7 @@ describe('element', () => {
   describe('elementHasValue', () => {
     it('finds and returns a single element', async () => {
       const element = await browser.assertElementHasValue('#text-input', 'initialvalue');
-      assert.equal('resolve the element\'s id', 'text-input', await element.getAttribute('id'));
+      assert.equal('resolve the element\'s id', 'text-input', await element.get('id'));
     });
 
     it('succeeds with empty string', () =>
@@ -153,7 +153,7 @@ describe('element', () => {
   describe('elementLacksValue', () => {
     it('asserts an element lacks some value, and returns the element', async () => {
       const element = await browser.assertElementLacksValue('#text-input', 'this text not present');
-      assert.equal('resolve the element\'s id', 'text-input', await element.getAttribute('id'));
+      assert.equal('resolve the element\'s id', 'text-input', await element.get('id'));
     });
 
     it('finds an element incorrectly having some text', async () => {

--- a/test/integration/element.test.js
+++ b/test/integration/element.test.js
@@ -259,32 +259,33 @@ describe('element', () => {
     });
   });
 
-  xdescribe('#getElement', () => {
+  describe('#getElement', () => {
     before(() => browser.navigateTo('/'));
 
-    it('succeeds if selector is a String', () => {
-      const element = browser.getElement('body');
-      element.getElement('.message');
+    it('succeeds if selector is a String', async () => {
+      const element = await browser.getElement('body');
+      await element.getElement('.message');
     });
 
-    it('return null if not found an element on the message element', () => {
-      const messageElement = browser.getElement('.message');
-      const element = messageElement.getElement('.message');
-      assert.falsey(element);
+    it('return null if not found an element on the message element', async () => {
+      const messageElement = await browser.getElement('.message');
+      const element = await messageElement.getElementOrNull('.message');
+      assert.equal(null, element);
     });
   });
 
-  xdescribe('#getElements', () => {
+  describe('#getElements', () => {
     before(() => browser.navigateTo('/'));
 
-    it('succeeds if selector is a String', () => {
-      const element = browser.getElement('body');
-      element.getElements('.message');
+    it('succeeds if selector is a String', async () => {
+      const element = await browser.getElement('body');
+      const messages = await element.getElements('.message');
+      assert.equal(3, messages.length);
     });
 
-    it('return empty array if not found an element on the message element', () => {
-      const messageElement = browser.getElement('.message');
-      const elements = messageElement.getElements('.message');
+    it('return empty array if not found an element on the message element', async () => {
+      const messageElement = await browser.getElement('.message');
+      const elements = await messageElement.getElements('.message');
       assert.equal(0, elements.length);
     });
   });

--- a/test/integration/evaluate.test.js
+++ b/test/integration/evaluate.test.js
@@ -1,22 +1,20 @@
-import {getBrowser} from '../mini-testium-mocha';
+import {browser} from '../mini-testium-mocha';
 import assert from 'assertive';
 
-xdescribe('evaluate', () => {
-  let browser;
-  before(async () => (browser = await getBrowser()));
+describe('evaluate', () => {
+  before(browser.beforeHook);
 
   before(() => browser.navigateTo('/'));
 
-  it('runs JavaScript passed as a String', () => {
-    const value = browser.evaluate('return 3;');
-    assert.equal(3, value);
+  it('runs JavaScript passed as a String', async () => {
+    assert.equal(3, await browser.evaluate('return 3;'));
   });
 
-  it('runs JavaScript passed as a Function', () => {
-    assert.equal(6, browser.evaluate(() => 6));
+  it('runs JavaScript passed as a Function', async () => {
+    assert.equal(6, await browser.evaluate(() => 6));
   });
 
-  it('runs JavaScript passed as a Function with optional prepended args', () => {
-    assert.equal(18, browser.evaluate(3, 6, (a, b) => a * b));
+  it('runs JavaScript passed as a Function with optional prepended args', async () => {
+    assert.equal(18, await browser.evaluate(3, 6, (a, b) => a * b));
   });
 });

--- a/test/integration/navigation.test.js
+++ b/test/integration/navigation.test.js
@@ -10,39 +10,35 @@ function assertRejects(promise) {
 describe('navigation', () => {
   before(browser.beforeHook);
 
-  it('supports just a path', async () => {
-    await browser.navigateTo('/');
-    assert.equal(200, await browser.getStatusCode());
+  it('supports just a path', () => {
+    return browser.navigateTo('/').assertStatusCode(200);
   });
 
-  it('supports query args', async () => {
-    await browser.navigateTo('/', { query: { 'a b': 'München', x: 0 } });
-    assert.equal(200, await browser.getStatusCode());
-
-    await browser.waitForPath('/?a%20b=M%C3%BCnchen&x=0', 100);
+  it('supports query args', () => {
+    return browser
+      .navigateTo('/', { query: { 'a b': 'München', x: 0 } })
+      .assertStatusCode(200)
+      .waitForPath('/?a%20b=M%C3%BCnchen&x=0', 100);
   });
 
-  it('with a query string and query arg', async () => {
-    await browser.navigateTo('/?x=0', { query: { 'a b': 'München' } });
-    assert.equal(200, await browser.getStatusCode());
-
-    await browser.waitForPath('/?x=0&a%20b=M%C3%BCnchen', 100);
+  it('with a query string and query arg', () => {
+    return browser
+      .navigateTo('/?x=0', { query: { 'a b': 'München' } })
+      .assertStatusCode(200)
+      .waitForPath('/?x=0&a%20b=M%C3%BCnchen', 100);
   });
 
   it('by clicking a link', async () => {
-    await browser.navigateTo('/');
-    assert.equal(200, await browser.getStatusCode());
-
     await browser
-      .elementByCssSelector('.link-to-other-page')
-      .click();
+      .navigateTo('/')
+      .assertStatusCode(200)
+      .clickOn('.link-to-other-page');
 
     assert.equal('/other-page.html', await browser.getPath());
   });
 
   it('by refreshing', async () => {
-    await browser.navigateTo('/');
-    assert.equal(200, await browser.getStatusCode());
+    await browser.navigateTo('/').assertStatusCode(200);
 
     await browser.safeExecute('(' + function changePage() {
       /* eslint no-var:0 */
@@ -50,13 +46,13 @@ describe('navigation', () => {
       el.className = 'exists-before-refresh';
       document.body.appendChild(el);
     }.toString() + ')();');
-    // Making sure the element exists
-    await browser.elementByCssSelector('.exists-before-refresh');
 
-    await browser.refresh();
-    // The element should not be gone.
-    assert.equal(null,
-      await browser.elementByCssSelectorOrNull('.exists-before-refresh'));
+    await browser
+      // Making sure the element exists
+      .assertElementExists('.exists-before-refresh')
+      .refresh()
+      // The element should not be gone.
+      .assertElementDoesntExist('.exists-before-refresh');
   });
 
   describe('waiting for a url', () => {
@@ -118,18 +114,18 @@ describe('navigation', () => {
   });
 
   describe('waiting for a path', () => {
-    it('can work with a string', async () => {
-      await browser.navigateTo('/redirect-after.html');
-      assert.equal(200, await browser.getStatusCode());
-
-      await browser.waitForPath('/index.html');
+    it('can work with a string', () => {
+      return browser
+        .navigateTo('/redirect-after.html')
+        .assertStatusCode(200)
+        .waitForPath('/index.html');
     });
 
-    it('can work with a regex', async () => {
-      await browser.navigateTo('/redirect-after.html');
-      assert.equal(200, await browser.getStatusCode());
-
-      await browser.waitForPath(/index.html/);
+    it('can work with a regex', () => {
+      return browser
+        .navigateTo('/redirect-after.html')
+        .assertStatusCode(200)
+        .waitForPath(/index.html/);
     });
   });
 });


### PR DESCRIPTION
* `browser.getElement`: Throws a clean exception if the element doesn't exist
* `browser.getElementOrNull`: Same behavior as `-sync`'s `getElement`