### PR TITLE
Port contributor info, add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Testium: wd driver
+
+Bindings that allow using the promise chain variant of [`wd`](https://github.com/admc/wd/) in testium.
+
+This project is a safe and inclusive place
+for contributors of all kinds.
+See the [Code of Conduct](CODE_OF_CONDUCT.md)
+for details.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,44 @@
     "wd",
     "webdriver"
   ],
-  "author": "Jan Krems <jan.krems@groupon.com>",
+  "author": {
+    "name": "Sean Massa",
+    "email": "endangeredmassa@gmail.com"
+  },
+  "contributors": [
+    {
+      "name": "Andrew Bloom"
+    },
+    {
+      "name": "azu",
+      "email": "info@efcl.info"
+    },
+    {
+      "name": "Chris Khoo",
+      "email": "chris.khoo@gmail.com"
+    },
+    {
+      "name": "Jan Krems",
+      "email": "jan.krems@gmail.com"
+    },
+    {
+      "name": "Jess Telford"
+    },
+    {
+      "name": "Joseph Núñez"
+    },
+    {
+      "name": "Johan Sundström"
+    },
+    {
+      "name": "Justin Searls",
+      "email": "justin@testdouble.com"
+    },
+    {
+      "name": "Parag Gupta",
+      "email": "paraggupta1993@gmail.com"
+    }
+  ],
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/testiumjs/testium-driver-wd/issues"


### PR DESCRIPTION
We split the original testium code into multiple repositores.
So even though it's no longer visible in the git history,
all these people contributed to the current state.

* Latest version of [Contributor Covenant](http://contributor-covenant.org/)
* Take contributors data from testium and apply to this repo
* List of contributors is alphabetically ordered
* E-Mails are only included if they were public (Github profile)