### PR TITLE
feat: add 2 missing methods

### DIFF
--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -170,3 +170,16 @@ exports.assertElementLacksValue = function assertElementLacksValue(selector, tex
   return this.assertElement(selector,
     asserters.fuzzyString('getValue', textOrRegExp, false, selector));
 };
+
+exports.assertElementHasAttributes =
+function assertElementHasAttributes(selector, attributesObject) {
+  assert.hasType('attributesObject should be an object', Object, attributesObject);
+  return this.assertElement(selector, {
+    assert: function assertAttributes(element) {
+      return Bluebird.all(_.map(attributesObject, function eachAttr(val, attr) {
+        var actualVal = element.getAttribute(attr);
+        return assert.equal('attribute ' + attr, val, actualVal);
+      }));
+    }
+  });
+};

--- a/lib/browser/form.js
+++ b/lib/browser/form.js
@@ -45,6 +45,7 @@ exports.type = function type(selector, value) {
 exports.clearAndType = function clearAndType(selector, value) {
   return this.getElement(selector).clear().type(value);
 };
+exports.setValue = exports.clearAndType;
 
 exports.fillFields = function fillFields(fields) {
   var self = this;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   },
   "dependencies": {
-    "assertive": "^2.0.2",
+    "assertive": "^2.1.1",
     "bluebird": "^3.3.3",
     "debug": "^2.2.0",
     "lodash": "^4.6.1",

--- a/test/integration/element.test.js
+++ b/test/integration/element.test.js
@@ -169,6 +169,22 @@ describe('element', () => {
     });
   });
 
+  describe('elementHasAttributes', () => {
+    before(() => browser.navigateTo('/'));
+
+    it('fails if element found does not have attrs', async () => {
+      const error = await assertRejects(
+        browser.assertElementHasAttributes('img.fail', { foo: 'bar' }));
+      const expected = 'Assertion failed: attribute foo\nExpected: "bar"\nActually: null';
+      assert.equal(expected, stripColors(error.message));
+    });
+
+    it('passes if element found has given attrs', async () => {
+      await browser.assertElementHasAttributes('img.fail',
+        { alt: 'a non-existent image' });
+    });
+  });
+
   describe('waitForElementExist', () => {
     before(() => browser.navigateTo('/dynamic.html'));
 


### PR DESCRIPTION
both were in the docs, but not actually implemented:

* `browser.setValue()` (alias for `browser.clearAndType()`)
* `browser.assertElementHasAttributes()`

Upgraded `assertive` to support assertions on promises