### PR TITLE
feat: add setCookieValues() method

### DIFF
--- a/lib/browser/cookie.js
+++ b/lib/browser/cookie.js
@@ -34,6 +34,7 @@
 var assert = require('assertive');
 var Bluebird = require('bluebird');
 var _ = require('lodash');
+var util = require('util');
 
 var getTestiumCookie = require('testium-cookie').getTestiumCookie;
 
@@ -56,8 +57,15 @@ exports.getCookieValue = function getCookieValue(name) {
   return this.getCookie(name).then(_.property('value'));
 };
 
-exports.setCookies = function setCookies(cookies) {
+exports.setCookies = util.deprecate(function setCookies(cookies) {
   return Bluebird.all(cookies.map(this.setCookie, this));
+}, 'setCookies() has poor defaults, use setCookieValues() instead');
+
+exports.setCookieValues = function setCookieValues(cookies) {
+  var browser = this;
+  return Bluebird.all(_.map(cookies, function setOneValue(value, name) {
+    return browser.setCookieValue(name, value);
+  }));
 };
 
 exports.getCookie = function getCookie(name) {

--- a/test/integration/cookie.test.js
+++ b/test/integration/cookie.test.js
@@ -1,6 +1,8 @@
 import { browser } from '../mini-testium-mocha';
 import assert from 'assertive';
 
+process.noDeprecation = true;
+
 describe('cookie', () => {
   before(browser.beforeHook);
 
@@ -16,7 +18,7 @@ describe('cookie', () => {
     assert.equal('3', cookie.value);
   });
 
-  it('can be set in groups', async () => {
+  it('can be set in groups with deprecated setCookies()', async () => {
     await browser.setCookies([
       { name: 'test_cookie1', value: '5', domain: '127.0.0.1', path: '/' },
       { name: 'test_cookie2', value: '7', domain: '127.0.0.1', path: '/' },
@@ -27,6 +29,16 @@ describe('cookie', () => {
 
     assert.equal('5', cookie1.value);
     assert.equal('7', cookie2.value);
+  });
+
+  it('can be set in groups with setCookieValues()', async () => {
+    await browser.setCookieValues({
+      test_cookie3: '9',
+      test_cookie4: '11',
+    });
+
+    assert.equal('9', await browser.getCookieValue('test_cookie3'));
+    assert.equal('11', await browser.getCookieValue('test_cookie4'));
   });
 
   it('can be cleared as a group', async () => {


### PR DESCRIPTION
* takes `{ [name]: value, ... }` object
* uses `setCookieValue()` under the hood
* supplants `setCookies()` (now deprecated)