### PR TITLE
fix: fallback default for setCookieValue

### DIFF
--- a/lib/browser/cookie.js
+++ b/lib/browser/cookie.js
@@ -47,7 +47,7 @@ exports.setCookieValue = function setCookieValue(name, value, options) {
     name: name,
     value: value,
     path: '/',
-    domain: this.defaultCookieDomain,
+    domain: this.defaultCookieDomain || '127.0.0.1',
     secure: false
   }, options || {});
   return this.setCookie(cookie);


### PR DESCRIPTION
The changes for remote browser included defaulting the cookie domain to
browser.defaultCookieDomain, which doesn't work inside a mixed-in wd
method.  This doesn't fix that problem, but makes the basic cookie code
at least work again for validating browsers (e.g. phantomjs 2.x)

See: https://github.com/testiumjs/testium-driver-wd/issues/19