### PR TITLE
feat: add browser.loadPage as better navigateTo

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -36,6 +36,7 @@ var path = require('path');
 var debug = require('debug')('testium-driver-wd');
 var _ = require('lodash');
 var wd = require('wd');
+var assert = require('assertive');
 
 var defaultMethods = [
   /* eslint-disable global-require */
@@ -84,6 +85,32 @@ function initDriver(testium) {
     var targetUrl = testium.getNewPageUrl(url, options);
     debug('navigateTo', targetUrl);
     return this.get(targetUrl);
+  });
+
+  wd.addPromiseChainMethod('loadPage', function loadPage(url, options) {
+    options = options || {};
+
+    var code = 200;
+    if (options.expectedStatusCode) {
+      code = options.expectedStatusCode;
+      delete options.statusCode;
+      if (_.isString(code)) code = parseInt(code, 10);
+    }
+
+    var assertCode;
+    if (_.isNumber(code)) {
+      assertCode = function eq(s) { assert.equal('statusCode', code, s); };
+    } else if (_.isRegExp(code)) {
+      assertCode = function re(s) { assert.match('statusCode', code, '' + s); };
+    } else if (_.isFunction(code)) {
+      assertCode = function fn(s) {
+        assert.expect('statusCode is as expected', code(s));
+      };
+    } else {
+      throw new Error('invalid expectedStatusCode option: ' + code);
+    }
+
+    return this.navigateTo(url, options).getStatusCode().then(assertCode);
   });
 
   wd.addPromiseChainMethod('switchToDefaultWindow', function switchToDefaultWindow() {

--- a/test/integration/navigation.test.js
+++ b/test/integration/navigation.test.js
@@ -128,4 +128,47 @@ describe('navigation', () => {
         .waitForPath(/index.html/)
     );
   });
+
+  describe('loadPage', () => {
+    describe('verifies status 200 by default', () => {
+      it('and resolves', () =>
+        browser
+          .loadPage('/')
+          .assertElementExists('.link-to-other-page')
+      );
+
+      it('and rejects', async () => {
+        const err = await assert.rejects(browser.loadPage('/missing'));
+        assert.match(/Expected:.+200[^]+Actually:.+404/, err.message);
+      });
+    });
+
+    describe('accepts a regexp', () => {
+      it('and resolves', () =>
+        browser.loadPage('/missing', { expectedStatusCode: /^404$/ })
+      );
+
+      it('and rejects', async () => {
+        const err = await assert.rejects(
+          browser.loadPage('/', { expectedStatusCode: /^404$/ })
+        );
+        assert.include('/^404$/\nto match:', err.message);
+      });
+    });
+
+    describe('accepts a function', () => {
+      it('and resolves', () =>
+        browser.loadPage('/missing', {
+          expectedStatusCode(s) { return (s / 2) === 202; },
+        })
+      );
+
+      it('and rejects', async () => {
+        const err = await assert.rejects(
+          browser.loadPage('/', { expectedStatusCode() { return false; } })
+        );
+        assert.include('is as expected', err.message);
+      });
+    });
+  });
 });


### PR DESCRIPTION
* passes thru to navigateTo
* defaults to equiv of `.assertStatusCode(200)`
* accepts in options `{ expectedStatusCode: Number|RegExp|Function }`