### PR TITLE
fix: support `mixins.wd[] = 'some-module'`

### DIFF
--- a/.testiumrc
+++ b/.testiumrc
@@ -4,6 +4,6 @@
     "command": "testium-example-app"
   },
   "mixins": {
-    "wd": [ "test/mixin.js" ]
+    "wd": [ "test/mixin.js", "test-mixin-module" ]
   }
 }

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -62,8 +62,24 @@ function applyMethods(methods) {
 
 function applyMixin(mixin) {
   debug('Applying mixin to wd', mixin);
-  var mixinFile = path.resolve(process.cwd(), mixin);
-  applyMethods(require(mixinFile)); // eslint-disable-line global-require
+  // this is all to be bug-compatible with our old implementation, which
+  // would parse a mixin path of "test/blah" the same as "./test/blah"
+  var cwd = process.cwd();
+  var paths = [path.resolve(cwd, mixin), path.resolve(cwd, 'node_modules', mixin)];
+  var mixins;
+  _.forEach(paths, function eachFile(mixinFile) {
+    try {
+      mixins = require(mixinFile); // eslint-disable-line global-require
+      return false;
+    } catch (err) {
+      if (err.code !== 'MODULE_NOT_FOUND') throw err;
+      return undefined;
+    }
+  });
+  if (!mixins) {
+    throw new Error('couldn\'t find ' + mixin + ' in ' + paths.join(' or '));
+  }
+  applyMethods(mixins);
 }
 
 function initDriver(testium) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-groupon": "^3.2.0",
     "eslint-config-groupon-es5": "^3.0.0",
     "eslint-plugin-import": "^1.6.1",
+    "test-mixin-module": "file:./test/test-mixin-module",
     "mocha": "^3.1.2",
     "nlm": "^3.0.0",
     "testium-core": "^1.3.0",

--- a/test/integration/mixin.test.js
+++ b/test/integration/mixin.test.js
@@ -4,7 +4,11 @@ import assert from 'assertive';
 describe('mixin', () => {
   before(browser.beforeHook);
 
-  it('exposes the mixed-in method', async () => {
+  it('exposes the relative path mixed-in method', async () => {
     assert.equal(10, await browser.mixedInMethod());
+  });
+
+  it('exposes the external module mixed-in method', async () => {
+    assert.equal(42, await browser.anotherMethod());
   });
 });

--- a/test/test-mixin-module/index.js
+++ b/test/test-mixin-module/index.js
@@ -1,0 +1,3 @@
+exports.anotherMethod = function anotherMethod() {
+  return 42;
+};

--- a/test/test-mixin-module/package.json
+++ b/test/test-mixin-module/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-mixin-module",
+  "version": "0.0.0",
+  "description": "Mixin Fake Test Module"
+}


### PR DESCRIPTION
Per the docs:

> Each setting is an array of module names that will be resolved
> relative to the working directory. E.g. `./test/mixins/session.js` will
> be resolved to `${cwd}/test/mixins/session.js` and `mixins/session` may be
> resolved to `${cwd}/node_modules/mixins/session.js`.

That wasn't true before this, but since some people may depend on the
old behavior to put something like `test/some-file`, we first check for
working local path, then try prepending node_modules.