### PR TITLE
feat: show long stack traces on errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '0.10'
   - '4'
+  - '6'
 before_install:
   - npm install -g npm@latest-2
 before_deploy:
@@ -13,4 +13,4 @@ deploy:
   skip_cleanup: true
   'on':
     branch: master
-    node: '4'
+    node: '6'

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -33,6 +33,12 @@
 
 var path = require('path');
 
+var q = require('q');
+q.longStackSupport = true;
+
+var bluebird = require('bluebird');
+bluebird.config({ longStackTraces: true });
+
 var debug = require('debug')('testium-driver-wd');
 var _ = require('lodash');
 var wd = require('wd');

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bluebird": "^3.3.3",
     "debug": "^2.2.0",
     "lodash": "^4.6.1",
+    "q": "1.4.1",
     "testium-cookie": "^1.0.0",
     "wd": "^1.0.0"
   },
@@ -39,9 +40,9 @@
     "eslint-config-groupon": "^3.2.0",
     "eslint-config-groupon-es5": "^3.0.0",
     "eslint-plugin-import": "^1.6.1",
-    "test-mixin-module": "file:./test/test-mixin-module",
     "mocha": "^3.1.2",
     "nlm": "^3.0.0",
+    "test-mixin-module": "file:./test/test-mixin-module",
     "testium-core": "^1.3.0",
     "testium-example-app": "^2.1.0"
   },


### PR DESCRIPTION
We use bluebird, wd uses q - both support long stack traces.  Our
current stack traces are fairly useless - this lets you at least see
which test file the error happened in

before:
```
not ok 2 App responds with 200
  Error: Assertion failed: statusCode
  Expected: 200
  Actually: 302
      at error (node_modules/testium-driver-wd/node_modules/assertive/lib/assertive.js:103:10)
      at equal (node_modules/testium-driver-wd/node_modules/assertive/lib/assertive.js:299:13)
      at Object._oneTest [as equal] (node_modules/testium-driver-wd/node_modules/assertive/lib/assertive.js:533:15)
      at compareTo (node_modules/testium-driver-wd/lib/browser/cookie.js:101:14)
      at _fulfilled (node_modules/wd/node_modules/q/q.js:834:54)
      at self.promiseDispatch.done (node_modules/wd/node_modules/q/q.js:863:30)
      at Promise.promise.promiseDispatch (node_modules/wd/node_modules/q/q.js:796:13)
      at node_modules/wd/node_modules/q/q.js:604:44
      at runSingle (node_modules/wd/node_modules/q/q.js:137:13)
      at flush (node_modules/wd/node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```

after:
```
not ok 2 App responds with 200
  Error: Assertion failed: statusCode
  Expected: 200
  Actually: 302
      at error (node_modules/testium-driver-wd/node_modules/assertive/lib/assertive.js:103:10)
      at equal (node_modules/testium-driver-wd/node_modules/assertive/lib/assertive.js:299:13)
      at Object._oneTest [as equal] (node_modules/testium-driver-wd/node_modules/assertive/lib/assertive.js:533:15)
      at compareTo (node_modules/testium-driver-wd/lib/browser/cookie.js:101:14)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
  From previous event:
      at Promise.promise.(anonymous function) [as then] (node_modules/wd/lib/promise-webdriver.js:127:32)
      at Context.<anonymous> (test/integration/app.test.coffee:24:10)
```

(good part is that very last line)