### PR TITLE
feat: browser.assertElementsNumber(selector, num)

### DIFF
--- a/lib/browser/_asserters.js
+++ b/lib/browser/_asserters.js
@@ -117,3 +117,14 @@ exports.fuzzyString = function assertFuzzyString(extract, expected, shouldMatch,
     });
   });
 };
+
+exports.elementsNumber = function assertElementsNumber(num, selector) {
+  return new Asserter(function checkNum(elems) {
+    var found = elems.length;
+    if (found !== num) {
+      throw new AssertionError(
+        selector + ' should match ' + num + ' elements - actually found ' + found
+      );
+    }
+  });
+};

--- a/lib/browser/element.js
+++ b/lib/browser/element.js
@@ -183,3 +183,11 @@ function assertElementHasAttributes(selector, attributesObject) {
     }
   });
 };
+
+exports.assertElementsNumber = function assertElementsNumber(selector, num) {
+  return this.elementsByCssSelector(selector)
+    .then(function assertNumber(elems) {
+      asserters.elementsNumber(num, selector).assert(elems);
+      return elems;
+    });
+};

--- a/test/integration/element.test.js
+++ b/test/integration/element.test.js
@@ -185,6 +185,22 @@ describe('element', () => {
     });
   });
 
+  describe('assertElementsNumber', () => {
+    before(() => browser.loadPage('/'));
+
+    it('fails if number of elements does not match', async () => {
+      const error = await assertRejects(
+        browser.assertElementsNumber('.message', 2));
+      const expected = '.message should match 2 elements - actually found 3';
+      assert.equal(expected, stripColors(error.message));
+    });
+
+    it('passes for right number of elements and returns them', async () => {
+      const elems = await browser.assertElementsNumber('.message', 3);
+      assert.equal(3, elems.length);
+    });
+  });
+
   describe('waitForElementExist', () => {
     before(() => browser.navigateTo('/dynamic.html'));
 


### PR DESCRIPTION
One of the most common needs to drop to `.then()` we've seen is people
checking the number of matched elements present - might as well make it
a supported assertion.