### PR TITLE
fix: don't pass expectedStatusCode thru as option

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -117,7 +117,7 @@ function initDriver(testium) {
     var code = 200;
     if (options.expectedStatusCode) {
       code = options.expectedStatusCode;
-      delete options.statusCode;
+      delete options.expectedStatusCode;
       if (_.isString(code)) code = parseInt(code, 10);
     }
 


### PR DESCRIPTION
`loadPage()` had a typo which was leaking `expectedStatusCode` into the
options passed to `navigateTo()`