### PR TITLE
generate a default X-Request-Id header

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -35,6 +35,7 @@
 const path = require('path');
 
 const bluebird = require('bluebird');
+const uuidV1 = require('uuid/v1');
 
 try {
   // if a promise has already been created, this will error
@@ -98,6 +99,11 @@ function applyMixin(mixin) {
   applyMethods(mixins);
 }
 
+function makeRequestId(currentTest) {
+  // currently, per RFC 7230, allow all visible ASCII characters
+  return `${currentTest} ${uuidV1()}`.replace(/[^ -~]+/g, '-');
+}
+
 function initDriver(testium) {
   _.each(defaultMethods, applyMethods);
   _.each(testium.config.get('mixins.wd', []), applyMixin);
@@ -114,8 +120,15 @@ function initDriver(testium) {
 
   wd.addPromiseChainMethod('navigateTo', function navigateTo(url, options) {
     options = options || {};
+    const currentTest = testium.browser.currentTest;
+    if (currentTest) {
+      options.headers = options.headers || {};
+      if (!options.headers['x-request-id']) {
+        options.headers['x-request-id'] = makeRequestId(currentTest);
+      }
+    }
     const targetUrl = testium.getNewPageUrl(url, options);
-    debug('navigateTo', targetUrl);
+    debug('navigateTo', targetUrl, currentTest);
     return this.get(targetUrl);
   });
 

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "debug": "^2.2.0",
     "lodash": "^4.6.1",
     "testium-cookie": "^1.0.0",
+    "uuid": "^3.1.0",
     "wd": "^1.0.0"
   },
   "devDependencies": {
-    "assertive": "^2.1.0",
     "eslint": "^4.7.1",
     "eslint-config-groupon": "^5.0.0",
     "eslint-plugin-import": "^2.8.0",

--- a/test/integration/header.test.js
+++ b/test/integration/header.test.js
@@ -42,4 +42,33 @@ describe('header', () => {
       })
     );
   });
+
+  describe('x-request-id', () => {
+    it(
+      'is defaulted to something useful',
+      coroutine(function*() {
+        const source = yield browser
+          .loadPage('/echo')
+          .getElement('body')
+          .text();
+        const reqId = JSON.parse(source).headers['x-request-id'];
+        // 'header' because this file is named 'header.test.js',
+        // and that's what mini-testium-mocha sets the currentTest to
+        assert.match(/^header [0-9a-f-]{36}$/, reqId);
+      })
+    );
+
+    it(
+      'properly escapes bogus header content chars',
+      coroutine(function*() {
+        browser.__proto__.currentTest = 'w x\n\ny\t💩\tz';
+        const source = yield browser
+          .loadPage('/echo')
+          .getElement('body')
+          .text();
+        const reqId = JSON.parse(source).headers['x-request-id'];
+        assert.match(/^w x-y-z [0-9a-f-]{36}$/, reqId);
+      })
+    );
+  });
 });

--- a/test/mini-testium-mocha.js
+++ b/test/mini-testium-mocha.js
@@ -9,9 +9,15 @@ const createDriver = require('../');
 const browser = {};
 exports.browser = browser;
 
-browser.beforeHook = () => () =>
-  getTestium({ driver: createDriver }).then(testium => {
-    browser.__proto__ = testium.browser;
-  });
+browser.beforeHook = () => {
+  const currentTest = new Error().stack
+    .split(/\n/)[2]
+    .replace(/.+\(.+\/(.+?)(?:\.test)\.(?:js|coffee):\d+:\d+\)$/, '$1');
+  return () =>
+    getTestium({ driver: createDriver }).then(testium => {
+      browser.__proto__ = testium.browser;
+      browser.__proto__.currentTest = currentTest;
+    });
+};
 
 after(() => browser && browser.quit && browser.quit());


### PR DESCRIPTION
To aid in determining which requests to your SOA stack are which, sets a
default X-Request-Id header, with (if available), the currentTest
property supplied by testium-mocha@>=2.1.1 and a v1 UUID

This will be usable once https://github.com/testiumjs/testium-mocha/pull/13 ships