### PR TITLE
use all `desiredCapabilities` in driver

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -167,7 +167,7 @@ function initDriver(testium) {
   const seleniumUrl = testium.config.get('selenium.serverUrl');
   const driver = wd.remote(seleniumUrl, 'promiseChain');
 
-  const browser = driver.init({ browserName: testium.config.get('browser') });
+  const browser = driver.init(testium.config.get('desiredCapabilities'));
   browser.appUrl = `http://127.0.0.1:${testium.config.get('app.port')}`;
   browser.defaultCookieDomain = testium.config.get(
     'proxy.host',


### PR DESCRIPTION
before we were just passing the browser, but `testium-core` mixes the
browser into the proper spot in `desiredCapabilities` anyway, so now we
get all of them