### PR TITLE
feat: expose getChromeDevtoolsPort method

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -164,6 +164,13 @@ function initDriver(testium) {
     }
   );
 
+  wd.addPromiseChainMethod(
+    'getChromeDevtoolsPort',
+    function getChromeDevtoolsPort() {
+      return testium.getChromeDevtoolsPort();
+    }
+  );
+
   const seleniumUrl = testium.config.get('selenium.serverUrl');
   const driver = wd.remote(seleniumUrl, 'promiseChain');
 

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -82,6 +82,7 @@ function applyMixin(mixin) {
       return false;
     } catch (err) {
       if (err.code !== 'MODULE_NOT_FOUND') throw err;
+      // eslint-disable-next-line consistent-return
       return undefined;
     }
   });
@@ -164,11 +165,8 @@ function initDriver(testium) {
     }
   );
 
-  wd.addPromiseChainMethod(
-    'getChromeDevtoolsPort',
-    function getChromeDevtoolsPort() {
-      return testium.getChromeDevtoolsPort();
-    }
+  wd.addPromiseChainMethod('getChromeDevtoolsPort', () =>
+    testium.getChromeDevtoolsPort()
   );
 
   const seleniumUrl = testium.config.get('selenium.serverUrl');


### PR DESCRIPTION
- [x] expose getChromeDevtoolsPort method. It would be called from browser.getXPort and be used as needed