### PR TITLE
Add puppeteer and lighthouse integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
+  - '10'
 deploy:
   provider: script
   script: ./node_modules/.bin/nlm release

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -232,7 +232,8 @@ function initDriver(testium) {
   });
 
   wd.addPromiseChainMethod('getLighthouseData', function getLighthouseData(
-    flags
+    flags,
+    config
   ) {
     if (!lighthouse) {
       throw new Error('Lighthouse requires a newer version of node');
@@ -240,7 +241,7 @@ function initDriver(testium) {
     const devtoolsPort = testium.getChromeDevtoolsPort();
     const options = Object.assign({ port: devtoolsPort }, flags);
     return this.url().then(url => {
-      return lighthouse(url, options);
+      return lighthouse(url, options, config);
     });
   });
 

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -40,6 +40,17 @@ const debug = require('debug')('testium-driver-wd');
 const _ = require('lodash');
 const wd = require('wd');
 const assert = require('assertive');
+const Gofer = require('gofer');
+const Puppeteer = require('puppeteer');
+const PuppeteerDeviceDescriptors = require('puppeteer/DeviceDescriptors');
+
+// Lighthouse uses node 8 syntax, so we need to make this optional
+let lighthouse = null;
+try {
+  lighthouse = require('lighthouse');
+} catch (e) {
+  if (e.name !== 'SyntaxError') throw e;
+}
 
 wd.Q.longStackSupport = true;
 
@@ -168,6 +179,70 @@ function initDriver(testium) {
   wd.addPromiseChainMethod('getChromeDevtoolsPort', () =>
     testium.getChromeDevtoolsPort()
   );
+
+  let puppeteerBrowserSingleton;
+  function ensurePuppeteerBrowser() {
+    if (!puppeteerBrowserSingleton) {
+      const devtoolsPort = testium.getChromeDevtoolsPort();
+      puppeteerBrowserSingleton = Gofer.fetch(
+        `http://127.00.1:${devtoolsPort}/json`
+      )
+        .json()
+        .then(targets => targets.filter(target => target.type === 'page'))
+        .then(pages =>
+          Puppeteer.connect({
+            // Any random one will work
+            browserWSEndpoint: pages[0].webSocketDebuggerUrl,
+          })
+        );
+    }
+    return puppeteerBrowserSingleton;
+  }
+
+  let puppeteerPage;
+  function ensurePuppeteerPage() {
+    if (!puppeteerPage) {
+      puppeteerPage = ensurePuppeteerBrowser()
+        .then(puppeteerBrowser => puppeteerBrowser.pages())
+        .then(pages => {
+          // We'll guess and just take the first page.
+          // In *theory* testiumRootWindow should be CDwindow-${targetId}. E.g.:
+          // const windowHandle = testiumRootWindow.replace(/^CDwindow-/, '');
+          // const targetId = pages[0].target()['_targetInfo'].targetId;
+          // console.log({
+          //   windowHandle,
+          //   targetId,
+          //   matches: windowHandle === targetId,
+          // });
+          return pages[0];
+        });
+    }
+    return puppeteerPage;
+  }
+
+  wd.addPromiseChainMethod('withPuppeteerPage', fn => {
+    return ensurePuppeteerPage().then(fn);
+  });
+
+  wd.addPromiseChainMethod('emulate', deviceDescriptor => {
+    if (typeof deviceDescriptor === 'string') {
+      deviceDescriptor = PuppeteerDeviceDescriptors[deviceDescriptor];
+    }
+    return ensurePuppeteerPage().then(page => page.emulate(deviceDescriptor));
+  });
+
+  wd.addPromiseChainMethod('getLighthouseData', function getLighthouseData(
+    flags
+  ) {
+    if (!lighthouse) {
+      throw new Error('Lighthouse requires a newer version of node');
+    }
+    const devtoolsPort = testium.getChromeDevtoolsPort();
+    const options = Object.assign({ port: devtoolsPort }, flags);
+    return this.url().then(url => {
+      return lighthouse(url, options);
+    });
+  });
 
   const seleniumUrl = testium.config.get('selenium.serverUrl');
   const driver = wd.remote(seleniumUrl, 'promiseChain');

--- a/package.json
+++ b/package.json
@@ -28,12 +28,16 @@
   "dependencies": {
     "assertive": "^2.1.1",
     "debug": "^2.2.0",
+    "gofer": "^3.5.8",
+    "lighthouse": "^3.0.1",
     "lodash": "^4.6.1",
+    "puppeteer": "^1.5.0",
     "testium-cookie": "^1.0.0",
     "uuid": "^3.1.0",
     "wd": "^1.0.0"
   },
   "devDependencies": {
+    "chromedriver": "^2.40.0",
     "co": "^4.6.0",
     "eslint": "^4.7.1",
     "eslint-config-groupon": "^6.0.0",
@@ -44,8 +48,9 @@
     "mocha": "^3.1.2",
     "nlm": "^3.0.0",
     "prettier": "^1.6.1",
+    "semver": "^5.5.0",
     "test-mixin-module": "file:./test/test-mixin-module",
-    "testium-core": "^1.3.0",
+    "testium-core": "^1.10.0",
     "testium-example-app": "^2.1.0"
   },
   "author": {

--- a/test/integration/puppeteer.test.js
+++ b/test/integration/puppeteer.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const assert = require('assertive');
+const co = require('co');
+const getConfig = require('testium-core').getConfig;
+const Semver = require('semver');
+
+const browser = require('../mini-testium-mocha').browser;
+
+const browserName = getConfig().get('browser');
+
+describe('navigation', () => {
+  if (browserName !== 'chrome') {
+    xit('Skipping puppeteer tests. They only work for chrome.');
+    return;
+  }
+
+  before(browser.beforeHook());
+
+  if (Semver.satisfies(process.version, '>=8.0.0')) {
+    it(
+      'can get lighthouse report data',
+      co.wrap(function*() {
+        yield browser.navigateTo('/draggable.html').assertStatusCode(200);
+        const results = yield browser.getLighthouseData();
+        const report = results.report;
+        assert.match(/\/draggable\.html$/, JSON.parse(report).finalUrl);
+      })
+    );
+  } else {
+    it(
+      'is helpful in the way it reports the lack of lighthouse support',
+      co.wrap(function*() {
+        yield browser.navigateTo('/draggable.html').assertStatusCode(200);
+        const error = yield assert.rejects(browser.getLighthouseData());
+        assert.equal(
+          'Lighthouse requires a newer version of node',
+          error.message
+        );
+      })
+    );
+  }
+
+  it(
+    'exposes device emulation',
+    co.wrap(function*() {
+      yield browser.emulate('iPhone 6');
+      yield browser.navigateTo('/').assertStatusCode(200);
+      assert.include(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X)',
+        yield browser.evaluate(() => {
+          /* eslint-env browser */
+          return navigator.userAgent;
+        })
+      );
+    })
+  );
+});


### PR DESCRIPTION
This will expose a `browser.withPuppeteerPage()` API that can be used to access all puppeteer page APIs. It's now also possible to run lighthouse reports using `browser.getLighthouseData()`.

The lighthouse method takes the active URL, opens a new tab, and then reloads a bunch of times. This behavior is part of lighthouse.

---
_This PR was started by: [git wf pr](https://github.groupondev.com/InteractionTier/workflow-cli/releases/tag/v1.7.0)_