### PR TITLE
feat: Add supporting APIs for lighthouse

### DIFF
--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -151,7 +151,11 @@ const parseLhResult = function(results) {
   };
 };
 
-exports.assertLighthouseScore =function assertLighthouseScore(score, flags, config) {
+exports.assertLighthouseScore = function assertLighthouseScore(
+  score,
+  flags,
+  config
+) {
   const assertScore = function aScore(res) {
     assert.expect(parseLhResult(res).isSuccess(score));
   };
@@ -159,10 +163,10 @@ exports.assertLighthouseScore =function assertLighthouseScore(score, flags, conf
   return this.getLighthouseData(flags, config || lhConfig).then(assertScore);
 };
 
-exports.runLighthouseAudit =function runLighthouseAudit(flags, config) {
+exports.runLighthouseAudit = function runLighthouseAudit(flags, config) {
   const assertScore = function aScore(res) {
     assert.expect(parseLhResult(res).isSuccess(score));
   };
 
-  return this.getLighthouseData(flags, config || lhConfig).then(parseLhResult)
+  return this.getLighthouseData(flags, config || lhConfig).then(parseLhResult);
 };

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -90,7 +90,7 @@ const lhConfig = {
 
 const parseLhResult = function(results) {
   if (!results || !results.lhr || !results.lhr.audits) {
-    return null;
+    throw new Error(`Error fetching lighthouse audit results`);
   }
 
   const audits = results.lhr.audits;

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -33,7 +33,7 @@
 'use strict';
 
 const assert = require('assertive');
-const { isEmpty } = require('lodash');
+const isEmpty = require('lodash/isEmpty');
 
 function getTotalScore(success, failure) {
   const successCount = Object.keys(success).length;
@@ -164,9 +164,5 @@ exports.assertLighthouseScore = function assertLighthouseScore(
 };
 
 exports.runLighthouseAudit = function runLighthouseAudit(flags, config) {
-  const assertScore = function aScore(res) {
-    assert.expect(parseLhResult(res).isSuccess(score));
-  };
-
   return this.getLighthouseData(flags, config || lhConfig).then(parseLhResult);
 };

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -32,6 +32,9 @@
 
 'use strict';
 
+const assert = require('assertive');
+const { isEmpty } = require('lodash');
+
 function getTotalScore(success, failure) {
   const successCount = Object.keys(success).length;
   const errorCount = Object.keys(failure).length;
@@ -39,7 +42,7 @@ function getTotalScore(success, failure) {
   return (successCount * 100) / (successCount + errorCount);
 }
 
-exports.lhConfig = {
+const lhConfig = {
   passes: [
     {
       passName: 'accessibilityPass',
@@ -85,7 +88,7 @@ exports.lhConfig = {
   ],
 };
 
-exports.parseLhResult = function(results) {
+const parseLhResult = function(results) {
   if (!results || !results.lhr || !results.lhr.audits) {
     return null;
   }
@@ -112,8 +115,7 @@ exports.parseLhResult = function(results) {
       notApplicableObj[id] = auditInfo;
     } else if (scoreDisplayMode !== 'manual') {
       const snippets = [];
-
-      if (details.items && details.items.length) {
+      if (!isEmpty(details.items)) {
         details.items.forEach(item => snippets.push(item.node.snippet || ''));
       }
 
@@ -139,12 +141,28 @@ exports.parseLhResult = function(results) {
       const errorList = [];
 
       for (const id in errorsObj) {
-        const description = errorsObj[id];
-        const snippets = errorsObj[id];
+        const description = errorsObj[id].description;
+        const snippets = errorsObj[id].snippets;
         errorList.push(`${description}:\n\t${snippets.join('\n\t')}`);
       }
 
       return errorList.join('\n\n');
     },
   };
+};
+
+exports.assertLighthouseScore =function assertLighthouseScore(score, flags, config) {
+  const assertScore = function aScore(res) {
+    assert.expect(parseLhResult(res).isSuccess(score));
+  };
+
+  return this.getLighthouseData(flags, config || lhConfig).then(assertScore);
+};
+
+exports.runLighthouseAudit =function runLighthouseAudit(flags, config) {
+  const assertScore = function aScore(res) {
+    assert.expect(parseLhResult(res).isSuccess(score));
+  };
+
+  return this.getLighthouseData(flags, config || lhConfig).then(parseLhResult)
 };

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2015, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+function getTotalScore(success, failure) {
+  const successCount = Object.keys(success).length;
+  const errorCount = Object.keys(failure).length;
+
+  return successCount * 100 /(successCount + errorCount);
+}
+
+exports.lhConfig = {
+  passes: [
+    {
+      passName: 'accessibilityPass',
+      gatherers: ['accessibility'],
+    },
+  ],
+  audits: [
+    'accessibility/accesskeys',
+    'accessibility/aria-allowed-attr',
+    'accessibility/aria-required-attr',
+    'accessibility/aria-required-children',
+    'accessibility/aria-required-parent',
+    'accessibility/aria-roles',
+    'accessibility/aria-valid-attr-value',
+    'accessibility/aria-valid-attr',
+    'accessibility/audio-caption',
+    'accessibility/button-name',
+    'accessibility/bypass',
+    'accessibility/color-contrast',
+    'accessibility/definition-list',
+    'accessibility/dlitem',
+    'accessibility/document-title',
+    'accessibility/duplicate-id',
+    'accessibility/frame-title',
+    'accessibility/html-has-lang',
+    'accessibility/html-lang-valid',
+    'accessibility/image-alt',
+    'accessibility/input-image-alt',
+    'accessibility/label',
+    'accessibility/layout-table',
+    'accessibility/link-name',
+    'accessibility/list',
+    'accessibility/listitem',
+    'accessibility/meta-refresh',
+    'accessibility/meta-viewport',
+    'accessibility/object-alt',
+    'accessibility/tabindex',
+    'accessibility/td-headers-attr',
+    'accessibility/th-has-data-cells',
+    'accessibility/valid-lang',
+    'accessibility/video-caption',
+    'accessibility/video-description',
+  ],
+};
+
+exports.parseLhResult = (results) => {
+  if (!results || !results.lhr || !results.lhr.audits) {
+    return;
+  }
+
+  const { audits } = results.lhr;
+
+  const errorsObj = {};
+  const notApplicableObj = {};
+  const successObj = {};
+
+  for (const key in audits) {
+    const audit = audits[key];
+    const { description, details, id, score, scoreDisplayMode } = audit;
+
+    const auditInfo = { description, details };
+
+    if (score) {
+      successObj[id] = auditInfo;
+    } else if(scoreDisplayMode === 'not-applicable') {
+      notApplicableObj[id] = auditInfo;
+    } else if(scoreDisplayMode !== 'manual') {
+      const snippets = [];
+
+      if (details.items && details.items.length) {
+        details.items.forEach(({node}) => snippets.push(node.snippet || ''));
+      }
+
+      errorsObj[id] = { description, snippets };
+    }
+  };
+
+  const score = getTotalScore(successObj, errorsObj);
+
+  return {
+    audits,
+    score,
+    errors(type) {
+      return type ? errorsObj[type] : errorsObj;
+    },
+    errorString() {
+      const errorList = [];
+
+      for(const id in errorsObj) {
+        const { description, snippets } = errorsObj[id];
+        errorList.push(`${description}:\n\t${snippets.join('\n\t')}`);
+      }
+
+      return errorList.join('\n\n');
+    },
+    isSuccess(cutoff) {
+      return score >= cutoff;
+    },
+    success(type) {
+      return type ? successObj[type] : successObj;
+    }
+  }
+};

--- a/lib/lighthouse.js
+++ b/lib/lighthouse.js
@@ -36,7 +36,7 @@ function getTotalScore(success, failure) {
   const successCount = Object.keys(success).length;
   const errorCount = Object.keys(failure).length;
 
-  return successCount * 100 /(successCount + errorCount);
+  return (successCount * 100) / (successCount + errorCount);
 }
 
 exports.lhConfig = {
@@ -85,12 +85,12 @@ exports.lhConfig = {
   ],
 };
 
-exports.parseLhResult = (results) => {
+exports.parseLhResult = function(results) {
   if (!results || !results.lhr || !results.lhr.audits) {
-    return;
+    return null;
   }
 
-  const { audits } = results.lhr;
+  const audits = results.lhr.audits;
 
   const errorsObj = {};
   const notApplicableObj = {};
@@ -98,48 +98,53 @@ exports.parseLhResult = (results) => {
 
   for (const key in audits) {
     const audit = audits[key];
-    const { description, details, id, score, scoreDisplayMode } = audit;
+    const description = audit.description;
+    const details = audit.details;
+    const id = audit.id;
+    const score = audit.score;
+    const scoreDisplayMode = audit.scoreDisplayMode;
 
     const auditInfo = { description, details };
 
     if (score) {
       successObj[id] = auditInfo;
-    } else if(scoreDisplayMode === 'not-applicable') {
+    } else if (scoreDisplayMode === 'not-applicable') {
       notApplicableObj[id] = auditInfo;
-    } else if(scoreDisplayMode !== 'manual') {
+    } else if (scoreDisplayMode !== 'manual') {
       const snippets = [];
 
       if (details.items && details.items.length) {
-        details.items.forEach(({node}) => snippets.push(node.snippet || ''));
+        details.items.forEach(item => snippets.push(item.node.snippet || ''));
       }
 
       errorsObj[id] = { description, snippets };
     }
-  };
+  }
 
   const score = getTotalScore(successObj, errorsObj);
 
   return {
     audits,
     score,
+    isSuccess(cutoff) {
+      return score >= cutoff;
+    },
+    success(type) {
+      return type ? successObj[type] : successObj;
+    },
     errors(type) {
       return type ? errorsObj[type] : errorsObj;
     },
     errorString() {
       const errorList = [];
 
-      for(const id in errorsObj) {
-        const { description, snippets } = errorsObj[id];
+      for (const id in errorsObj) {
+        const description = errorsObj[id];
+        const snippets = errorsObj[id];
         errorList.push(`${description}:\n\t${snippets.join('\n\t')}`);
       }
 
       return errorList.join('\n\n');
     },
-    isSuccess(cutoff) {
-      return score >= cutoff;
-    },
-    success(type) {
-      return type ? successObj[type] : successObj;
-    }
-  }
+  };
 };

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -43,7 +43,7 @@ const assert = require('assertive');
 const Gofer = require('gofer');
 const Puppeteer = require('puppeteer');
 const PuppeteerDeviceDescriptors = require('puppeteer/DeviceDescriptors');
-const lighthouseHelper = require('./lighthouse');
+// const lighthouseHelper = require('./lighthouse');
 
 // Lighthouse uses node 8 syntax, so we need to make this optional
 let lighthouse = null;
@@ -66,6 +66,7 @@ const defaultMethods = [
   require('./browser/navigation'),
   require('./browser/page'),
   require('./browser/window'),
+  require('./browser/lighthouse'),
   /* eslint-enable */
 ];
 
@@ -242,29 +243,8 @@ function initDriver(testium) {
     const devtoolsPort = testium.getChromeDevtoolsPort();
     const options = Object.assign({ port: devtoolsPort }, flags);
     return this.url().then(url => {
-      return lighthouse(url, options, config || lighthouseHelper.lhConfig);
+      return lighthouse(url, options, config);
     });
-  });
-
-  wd.addPromiseChainMethod(
-    'assertLighthouseScore',
-    function assertLighthouseScore(score, flags, config) {
-      const assertScore = function aScore(res) {
-        assert.expect(lighthouseHelper.parseLhResult(res).isSuccess(score));
-      };
-
-      return this.getLighthouseData(flags, config).then(assertScore);
-    }
-  );
-
-  wd.addPromiseChainMethod('runLighthouseAudit', function runLighthouseAudit(
-    score,
-    flags,
-    config
-  ) {
-    return this.getLighthouseData(flags, config).then(
-      lighthouseHelper.parseLhResult
-    );
   });
 
   const seleniumUrl = testium.config.get('selenium.serverUrl');

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -43,7 +43,6 @@ const assert = require('assertive');
 const Gofer = require('gofer');
 const Puppeteer = require('puppeteer');
 const PuppeteerDeviceDescriptors = require('puppeteer/DeviceDescriptors');
-// const lighthouseHelper = require('./lighthouse');
 
 // Lighthouse uses node 8 syntax, so we need to make this optional
 let lighthouse = null;

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -43,7 +43,7 @@ const assert = require('assertive');
 const Gofer = require('gofer');
 const Puppeteer = require('puppeteer');
 const PuppeteerDeviceDescriptors = require('puppeteer/DeviceDescriptors');
-const { lhConfig, parseLhResult } = require('./lighthouse');
+const lighthouseHelper = require('./lighthouse');
 
 // Lighthouse uses node 8 syntax, so we need to make this optional
 let lighthouse = null;
@@ -242,20 +242,29 @@ function initDriver(testium) {
     const devtoolsPort = testium.getChromeDevtoolsPort();
     const options = Object.assign({ port: devtoolsPort }, flags);
     return this.url().then(url => {
-      return lighthouse(url, options, config || lhConfig);
+      return lighthouse(url, options, config || lighthouseHelper.lhConfig);
     });
   });
 
-  wd.addPromiseChainMethod('assertLighthouseScore', function assertLighthouseScore(score, flags, config) {
-    const assertScore = function aScore(res) {
-      assert.expect(parseLhResult(res).isSuccess(score));
-    };
+  wd.addPromiseChainMethod(
+    'assertLighthouseScore',
+    function assertLighthouseScore(score, flags, config) {
+      const assertScore = function aScore(res) {
+        assert.expect(lighthouseHelper.parseLhResult(res).isSuccess(score));
+      };
 
-    return this.getLighthouseData(flags, config).then(assertScore);
-  });
+      return this.getLighthouseData(flags, config).then(assertScore);
+    }
+  );
 
-  wd.addPromiseChainMethod('runLighthouseAudit', function runLighthouseAudit(score, flags, config) {
-    return this.getLighthouseData(flags, config).then(parseLhResult);
+  wd.addPromiseChainMethod('runLighthouseAudit', function runLighthouseAudit(
+    score,
+    flags,
+    config
+  ) {
+    return this.getLighthouseData(flags, config).then(
+      lighthouseHelper.parseLhResult
+    );
   });
 
   const seleniumUrl = testium.config.get('selenium.serverUrl');

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -43,6 +43,7 @@ const assert = require('assertive');
 const Gofer = require('gofer');
 const Puppeteer = require('puppeteer');
 const PuppeteerDeviceDescriptors = require('puppeteer/DeviceDescriptors');
+const { lhConfig, parseLhResult } = require('./lighthouse');
 
 // Lighthouse uses node 8 syntax, so we need to make this optional
 let lighthouse = null;
@@ -241,8 +242,20 @@ function initDriver(testium) {
     const devtoolsPort = testium.getChromeDevtoolsPort();
     const options = Object.assign({ port: devtoolsPort }, flags);
     return this.url().then(url => {
-      return lighthouse(url, options, config);
+      return lighthouse(url, options, config || lhConfig);
     });
+  });
+
+  wd.addPromiseChainMethod('assertLighthouseScore', function assertLighthouseScore(score, flags, config) {
+    const assertScore = function aScore(res) {
+      assert.expect(parseLhResult(res).isSuccess(score));
+    };
+
+    return this.getLighthouseData(flags, config).then(assertScore);
+  });
+
+  wd.addPromiseChainMethod('runLighthouseAudit', function runLighthouseAudit(score, flags, config) {
+    return this.getLighthouseData(flags, config).then(parseLhResult);
   });
 
   const seleniumUrl = testium.config.get('selenium.serverUrl');


### PR DESCRIPTION
**Purpose:**

Currently testium has an lighthouse API `getLighthouseData` which calls _lighthouse_ method and returns the response. Having additional APIs like `assertLighthouseScore()` or returning the parsed results,  would make the audits easy to integrate and use.

**Scope:**

This PR exposes above 2 APIs which can be consumed in either of following ways -
```
  context('Accessibility Tests version 1', () => {
    let lhResults;

    before(() =>
      browser
        .login('some-user')
        .loadPage('/some-page')
        .runLighthouseAudit()
        .then(audit => {lhResults = audit;})
    );

    after(() => browser.clearCookies());

    it(`checking for score over 85`, () => 
      assert.expect(`score is only ${lhResults.score}`, lhResults.isSuccess(85))
    );

    it(`There are no errors`, () => 
      assert.expect(lhResults.errorString(), Object.keys(lhResults.errors()).length === 0)
    );
  });

  context('Accessibility Tests version 2', () => {
    before(() =>
      browser
        .login('some-user')
        .loadPage('/some-page')
        .assertLighthouseScore(90)
    );

    after(() => browser.clearCookies());
  });
```

So this method call `runLighthouseAudit` resolves to an object  - which has 2 properties (can be exposed as methods too) _score_ (which is calculated based on success vs errors) and _audits_ which is value as returned from lighthouse call. It also has few methods to get errors/success as list of objects or return errors in the string format

**Future:**

- [x] It would be awesome to write results in a log file for any failures, also screenshots of the failures. Currently it just screenshots the browser, not the tools failures