### PR TITLE
feat: have loadPage() wait for load event by default

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -164,9 +164,17 @@ function initDriver(testium) {
       throw new Error(`invalid expectedStatusCode option: ${code}`);
     }
 
+    const waitForLoadEvent = options.waitForLoadEvent !== false;
+
+    let waitForLoadEventOrNull = function() {};
+    if (waitForLoadEvent) {
+      waitForLoadEventOrNull = this.waitForLoadEvent;
+    }
+
     return this.navigateTo(url, options)
       .getStatusCode()
-      .then(assertCode);
+      .then(assertCode)
+      .then(() => waitForLoadEventOrNull.call(this));
   });
 
   wd.addPromiseChainMethod(

--- a/test/integration/element.test.js
+++ b/test/integration/element.test.js
@@ -9,9 +9,12 @@ function stripColors(message) {
 }
 
 function assertRejects(promise) {
-  return promise.then(() => {
-    throw new Error('Did not fail as expected');
-  }, error => error);
+  return promise.then(
+    () => {
+      throw new Error('Did not fail as expected');
+    },
+    error => error
+  );
 }
 
 describe('element', () => {

--- a/test/integration/navigation.test.js
+++ b/test/integration/navigation.test.js
@@ -5,9 +5,12 @@ const assert = require('assertive');
 const co = require('co');
 
 function assertRejects(promise) {
-  return promise.then(() => {
-    throw new Error('Did not fail as expected');
-  }, error => error);
+  return promise.then(
+    () => {
+      throw new Error('Did not fail as expected');
+    },
+    error => error
+  );
 }
 
 describe('navigation', () => {
@@ -209,6 +212,31 @@ describe('navigation', () => {
             })
           );
           assert.include('is as expected', err.message);
+        })
+      );
+    });
+
+    describe('waiting for load event', () => {
+      it(
+        'happens by default',
+        co.wrap(function*() {
+          yield browser.loadPage('/index.html');
+          const state = yield browser.safeExecute(
+            `(${function getDocumentState() {
+              /* eslint-disable-next-line no-undef */
+              return document.readyState;
+            }})();`
+          );
+          assert.equal('complete', state);
+        })
+      );
+
+      it(
+        'can be overridden without browser rejecting',
+        co.wrap(function*() {
+          yield browser.loadPage('/index.html', {
+            waitForLoadEvent: false,
+          });
         })
       );
     });

--- a/test/integration/window.test.js
+++ b/test/integration/window.test.js
@@ -5,9 +5,12 @@ const assert = require('assertive');
 const co = require('co');
 
 function assertRejects(promise) {
-  return promise.then(() => {
-    throw new Error('Did not fail as expected');
-  }, error => error);
+  return promise.then(
+    () => {
+      throw new Error('Did not fail as expected');
+    },
+    error => error
+  );
 }
 
 describe('window api', () => {


### PR DESCRIPTION
These changes will apply the [`waitForLoadEvent`](https://github.com/testiumjs/testium-driver-wd/blob/d90a8e5c6e7cb151ba9cf1f7d19b9a105372b0cb/lib/browser/navigation.js#L146-L153) method by default to `browser.loadPage`, with a  new option `waitForLoadEvent` that will disable this behavior.

with modern improvements in how files can be dynamically loaded on the page, the browser should no longer be considered "ready" when the DOM is finished being parsed. The `window.onload` event is safer as a "load" indicator, as it will wait for all sub-resources to be downloaded (including those requested by previous resources or inline scripts).

I attempted to write some tests to explicitly test the disabling of this new behavior, but ran into trouble with checking the state of the browser between `DOMContentLoaded` and `window.onload`...its possible that a new stub could be properly set up within [`testium-example-app`](https://github.com/testiumjs/testium-example-app) that would help with this, but in my first attempt I was not able to do so