### PR TITLE
Switch to puppeteer-core

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -41,8 +41,8 @@ const _ = require('lodash');
 const wd = require('wd');
 const assert = require('assertive');
 const Gofer = require('gofer');
-const Puppeteer = require('puppeteer');
-const PuppeteerDeviceDescriptors = require('puppeteer/DeviceDescriptors');
+const Puppeteer = require('puppeteer-core');
+const PuppeteerDeviceDescriptors = require('puppeteer-core/DeviceDescriptors');
 
 // Lighthouse uses node 8 syntax, so we need to make this optional
 let lighthouse = null;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gofer": "^3.5.8",
     "lighthouse": "^3.0.1",
     "lodash": "^4.6.1",
-    "puppeteer": "^1.5.0",
+    "puppeteer-core": "^1.11.0",
     "testium-cookie": "^1.0.0",
     "uuid": "^3.1.0",
     "wd": "^1.10.1"

--- a/test/integration/puppeteer.test.js
+++ b/test/integration/puppeteer.test.js
@@ -9,7 +9,7 @@ const browser = require('../mini-testium-mocha').browser;
 
 const browserName = getConfig().get('browser');
 
-describe('navigation', () => {
+describe('puppeteer', () => {
   if (browserName !== 'chrome') {
     xit('Skipping puppeteer tests. They only work for chrome.');
     return;


### PR DESCRIPTION
This prevents the download of Chrome on every install of testium.

---
_This PR was started by: [git wf pr](https://github.groupondev.com/InteractionTier/workflow-cli/releases/tag/v1.8.1)_