### PR TITLE
[wip] feat: generalize lighthouse

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "groupon/node4"
+  "extends": "groupon/node6"
 }

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -34,6 +34,7 @@
 
 const assert = require('assertive');
 const isEmpty = require('lodash/isEmpty');
+const deepMerge = require('deepmerge');
 
 function getTotalScore(success, failure) {
   const successCount = Object.keys(success).length;
@@ -42,49 +43,29 @@ function getTotalScore(success, failure) {
   return (successCount * 100) / (successCount + errorCount);
 }
 
-const lhConfig = {
-  passes: [
-    {
-      passName: 'accessibilityPass',
-      gatherers: ['accessibility'],
+const defaultConfig = {
+  extends: 'lighthouse:default',
+  settings: {
+    onlyCategories: [],
+    throttlingMethod: 'simulate',
+  },
+};
+
+const categoryConfig = {
+  performance: {
+    settings: {
+      skipAudits: ['final-screenshot', 'is-on-https', 'screenshot-thumbnails'],
     },
-  ],
-  audits: [
-    'accessibility/manual/accesskeys',
-    'accessibility/aria-allowed-attr',
-    'accessibility/aria-required-attr',
-    'accessibility/aria-required-children',
-    'accessibility/aria-required-parent',
-    'accessibility/aria-roles',
-    'accessibility/aria-valid-attr-value',
-    'accessibility/aria-valid-attr',
-    'accessibility/audio-caption',
-    'accessibility/button-name',
-    'accessibility/bypass',
-    'accessibility/color-contrast',
-    'accessibility/definition-list',
-    'accessibility/dlitem',
-    'accessibility/document-title',
-    'accessibility/duplicate-id',
-    'accessibility/frame-title',
-    'accessibility/html-has-lang',
-    'accessibility/html-lang-valid',
-    'accessibility/image-alt',
-    'accessibility/input-image-alt',
-    'accessibility/label',
-    'accessibility/layout-table',
-    'accessibility/link-name',
-    'accessibility/list',
-    'accessibility/listitem',
-    'accessibility/meta-refresh',
-    'accessibility/meta-viewport',
-    'accessibility/object-alt',
-    'accessibility/tabindex',
-    'accessibility/td-headers-attr',
-    'accessibility/th-has-data-cells',
-    'accessibility/valid-lang',
-    'accessibility/video-caption',
-    'accessibility/video-description',
+  },
+};
+
+const defaultFlags = {
+  chromeFlags: [
+    '--disable-gpu',
+    '--headless',
+    '--disable-storage-reset',
+    '--enable-logging',
+    '--disable-device-emulation',
   ],
 };
 
@@ -94,7 +75,6 @@ const parseLhResult = function(results) {
   }
 
   const audits = results.lhr.audits;
-
   const errorsObj = {};
   const notApplicableObj = {};
   const successObj = {};
@@ -118,8 +98,10 @@ const parseLhResult = function(results) {
       notApplicableObj[id] = auditInfo;
     } else if (scoreDisplayMode !== 'manual') {
       const snippets = [];
-      if (!isEmpty(details.items)) {
-        details.items.forEach(item => snippets.push(item.node.snippet || ''));
+      if (details && !isEmpty(details.items)) {
+        details.items.forEach(item =>
+          snippets.push((item.node && item.node.snippet) || '')
+        );
       }
 
       errorsObj[id] = { description, snippets };
@@ -163,9 +145,45 @@ exports.assertLighthouseScore = function assertLighthouseScore(
     assert.expect(parseLhResult(res).isSuccess(score));
   };
 
-  return this.getLighthouseData(flags, config || lhConfig).then(assertScore);
+  return this.getLighthouseData(
+    flags,
+    config || categoryConfig.accessibility
+  ).then(assertScore);
 };
 
 exports.runLighthouseAudit = function runLighthouseAudit(flags, config) {
-  return this.getLighthouseData(flags, config || lhConfig).then(parseLhResult);
+  return this.getLighthouseData(flags, config).then(parseLhResult);
+};
+
+exports.runLHAccessibilityAudit = function runLHAccessibilityAudit(
+  flags,
+  config
+) {
+  return this.getLighthouseData(
+    flags || defaultFlags,
+    config || categoryConfig.accessibility
+  ).then(parseLhResult);
+};
+
+/**
+ *
+ * @param {string|Array<string>} categories - LH categories: 'performance', 'accessibility', 'best-practices', 'seo', 'pwa'
+ * @param {Object=} lhConfig - Custom Lighthouse config
+ * @return {Promise|*|PromiseLike<{score: *, errorString(): *, success(*): *, audits: any, errors(*): *, isSuccess(*): *} | never>|Promise<{score: *, errorString(): *, success(*): *, audits: any, errors(*): *, isSuccess(*): *} | never>}
+ */
+exports.runLighthouse = function runLighthouse(categories = [], lhConfig = {}) {
+  categories = !Array.isArray(categories) ? [categories] : categories;
+  let config = { ...defaultConfig };
+
+  categories.forEach(category => {
+    config.settings.onlyCategories.push(category.toLowerCase());
+    const catConfig = categoryConfig[category];
+    if (catConfig) {
+      config = deepMerge(config, catConfig);
+    }
+  });
+
+  config = deepMerge(config, lhConfig);
+
+  return this.getLighthouseData(defaultFlags, config).then(parseLhResult);
 };

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -34,7 +34,8 @@
 
 const assert = require('assertive');
 const isEmpty = require('lodash/isEmpty');
-const deepMerge = require('deepmerge');
+const merge = require('lodash/merge');
+const cloneDeep = require('lodash/cloneDeep');
 
 function getTotalScore(success, failure) {
   const successCount = Object.keys(success).length;
@@ -68,6 +69,20 @@ const defaultFlags = {
     '--disable-device-emulation',
   ],
 };
+
+/**
+ *
+ * @param config
+ * @return {Object}
+ */
+function getAccessibilityConfig(config) {
+  if (!config) {
+    config = cloneDeep(defaultConfig);
+    config.settings.onlyCategories.push('accessibility');
+  }
+
+  return config;
+}
 
 const parseLhResult = function(results) {
   if (!results || !results.lhr || !results.lhr.audits) {
@@ -145,45 +160,50 @@ exports.assertLighthouseScore = function assertLighthouseScore(
     assert.expect(parseLhResult(res).isSuccess(score));
   };
 
-  return this.getLighthouseData(
-    flags,
-    config || categoryConfig.accessibility
-  ).then(assertScore);
-};
-
-exports.runLighthouseAudit = function runLighthouseAudit(flags, config) {
-  return this.getLighthouseData(flags, config).then(parseLhResult);
-};
-
-exports.runLHAccessibilityAudit = function runLHAccessibilityAudit(
-  flags,
-  config
-) {
-  return this.getLighthouseData(
-    flags || defaultFlags,
-    config || categoryConfig.accessibility
-  ).then(parseLhResult);
+  return this.getLighthouseData(flags, getAccessibilityConfig(config)).then(
+    assertScore
+  );
 };
 
 /**
  *
  * @param {string|Array<string>} categories - LH categories: 'performance', 'accessibility', 'best-practices', 'seo', 'pwa'
  * @param {Object=} lhConfig - Custom Lighthouse config
- * @return {Promise|*|PromiseLike<{score: *, errorString(): *, success(*): *, audits: any, errors(*): *, isSuccess(*): *} | never>|Promise<{score: *, errorString(): *, success(*): *, audits: any, errors(*): *, isSuccess(*): *} | never>}
  */
 exports.runLighthouse = function runLighthouse(categories = [], lhConfig = {}) {
   categories = !Array.isArray(categories) ? [categories] : categories;
-  let config = { ...defaultConfig };
+  let config = cloneDeep(defaultConfig);
 
   categories.forEach(category => {
     config.settings.onlyCategories.push(category.toLowerCase());
     const catConfig = categoryConfig[category];
     if (catConfig) {
-      config = deepMerge(config, catConfig);
+      config = merge(config, catConfig);
     }
   });
 
-  config = deepMerge(config, lhConfig);
+  config = merge(config, lhConfig);
 
   return this.getLighthouseData(defaultFlags, config).then(parseLhResult);
+};
+
+/**
+ *
+ * @param {?Object}flags
+ * @param {?Object} lhConfig
+ */
+exports.runLighthouseAudit = function runLighthouseAudit(flags, lhConfig) {
+  return this.getLighthouseData(flags, lhConfig).then(parseLhResult);
+};
+
+/**
+ *
+ * @param {?Object}flags
+ * @param {?Object} lhConfig
+ */
+exports.runLighthouseA11y = function runLHAccessibilityAudit(flags, lhConfig) {
+  return this.getLighthouseData(
+    flags || defaultFlags,
+    getAccessibilityConfig(lhConfig)
+  ).then(parseLhResult);
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "assertive": "^2.4.1",
     "debug": "^4.1.1",
-    "deepmerge": "^3.2.0",
     "gofer": "^3.7.3",
     "lighthouse": "^4.1.0",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "assertive": "^2.4.1",
     "debug": "^4.1.1",
-    "gofer": "^3.5.8",
+    "deepmerge": "^3.2.0",
+    "gofer": "^3.7.3",
     "lighthouse": "^4.1.0",
     "lodash": "^4.17.11",
     "puppeteer": "^1.11.0",
@@ -37,7 +38,7 @@
     "wd": "^1.11.1"
   },
   "devDependencies": {
-    "chromedriver": "^2.45.0",
+    "chromedriver": "^2.46.0",
     "co": "^4.6.0",
     "eslint": "^4.7.1",
     "eslint-config-groupon": "^6.0.0",
@@ -46,11 +47,11 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.2.0",
     "mocha": "^5.2.0",
-    "nlm": "^3.6.0",
-    "prettier": "^1.6.1",
+    "nlm": "^3.6.1",
+    "prettier": "^1.16.4",
     "semver": "^5.6.0",
     "test-mixin-module": "file:./test/test-mixin-module",
-    "testium-core": "^1.10.0",
+    "testium-core": "^1.12.0",
     "testium-example-app": "^2.1.1"
   },
   "author": {


### PR DESCRIPTION
- [x] add `runLighthouse` to run multiple categories ('performance', 'accessibility', 'best-practices', 'seo', 'pwa')
- [x] keep `runLighthouseAudit` which previously ran only accessiblity audits
- [x] upgrade packages