### PR TITLE
feat: optional accessibility check with loadPage

### DIFF
--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -155,13 +155,17 @@ const parseLhResult = function(results) {
 };
 
 exports.assertLighthouseScore = function assertLighthouseScore(
-  score = 100,
+  score,
   flags,
   config
 ) {
+  score = score || 100;
   const assertScore = function aScore(res) {
     const results = parseLhResult(res);
-    assert.expect(`Accessibility Score ${results.score} to be greater than ${score}`, results.isSuccess(score));
+    assert.expect(
+      `Accessibility Score ${results.score} to be greater than ${score}`,
+      results.isSuccess(score)
+    );
   };
 
   return this.getLighthouseData(flags, config || lhConfig).then(assertScore);

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -50,7 +50,7 @@ const lhConfig = {
     },
   ],
   audits: [
-    'accessibility/manual/accesskeys',
+    'accessibility/accesskeys',
     'accessibility/aria-allowed-attr',
     'accessibility/aria-required-attr',
     'accessibility/aria-required-children',
@@ -155,12 +155,13 @@ const parseLhResult = function(results) {
 };
 
 exports.assertLighthouseScore = function assertLighthouseScore(
-  score,
+  score = 100,
   flags,
   config
 ) {
   const assertScore = function aScore(res) {
-    assert.expect(parseLhResult(res).isSuccess(score));
+    const results = parseLhResult(res);
+    assert.expect(`Accessibility Score ${results.score} to be greater than ${score}`, results.isSuccess(score));
   };
 
   return this.getLighthouseData(flags, config || lhConfig).then(assertScore);

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -165,10 +165,16 @@ function initDriver(testium) {
     }
 
     const waitForLoadEvent = options.waitForLoadEvent !== false;
+    const accessibilityChecks = options.accessibilityChecks === true;
 
     return this.navigateTo(url, options)
       .getStatusCode()
       .then(assertCode)
+      .then(
+        () =>
+          accessibilityChecks &&
+          this.assertLighthouseScore(options.accessibilityScore)
+      )
       .then(() => waitForLoadEvent && this.waitForLoadEvent());
   });
 


### PR DESCRIPTION
- move `accesskeys` from manual audit (https://github.com/GoogleChrome/lighthouse/pull/7129)
- pass default score (100) for assertion
- Support `accessibilityChecks` and `accessibilityScore` optional items to be under `options`

**Sample Call**

```
before(() =>
    browser.loadPage('/path', { accessibilityChecks: true })
);
```

**Screenshot**  (failure case) - 

![Screen Shot 2019-03-27 at 12 07 27 PM](https://user-images.githubusercontent.com/33071225/55096976-eb010e00-5088-11e9-8c28-f38e7b603c38.png)

