### PR TITLE
fix: pass flags to lighthouse audit from loadPage

### DIFF
--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -173,7 +173,7 @@ function initDriver(testium) {
       .then(
         () =>
           accessibilityChecks &&
-          this.assertLighthouseScore(options.accessibilityScore)
+          this.assertLighthouseScore(options.accessibilityScore, options.flags)
       )
       .then(() => waitForLoadEvent && this.waitForLoadEvent());
   });


### PR DESCRIPTION
Follow up PR from - https://github.com/testiumjs/testium-driver-wd/pull/43

Lighthouse runs audit in responsive mode by default, so we must pass flags through `loadPage` to also support desktop.

#### Sample call - 

For Mobile browsers -
```
browser.loadPage('/path', {
  headers: { 'X-Client-Platform': 'touch' },
  accessibilityChecks: true
})
```

For Desktop browsers -
```
browser.loadPage('/path', {
  accessibilityChecks: true,
  flags: { chromeFlags: ['--disable-device-emulation']}
})
```

Note: 
Though, it seemed intuitive to run accessibility audit along with `loadPage` call, it might be overhead to pass extra info in options. Possibly if we can find better way to identify the device and run audit accordingly (looking at the header?)

