### PR TITLE
feat: new a11yAudit function

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "groupon/node6"
+  "extends": "groupon/node8"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
 deploy:

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -174,3 +174,55 @@ exports.assertLighthouseScore = function assertLighthouseScore(
 exports.runLighthouseAudit = function runLighthouseAudit(flags, config) {
   return this.getLighthouseData(flags, config || lhConfig).then(parseLhResult);
 };
+
+exports.a11yAudit = function a11yAudit(options = {}) {
+  const { flags, config, ignore } = options;
+
+  let violationsFilter; // function to filter violations
+  if (typeof ignore === 'function') {
+    violationsFilter = violation => !ignore(violation);
+  } else if (Array.isArray(ignore)) {
+    // e.g. ignore: ['html-has-lang']
+    violationsFilter = violation => !ignore.includes(violation.id);
+  } else {
+    violationsFilter = () => true;
+  }
+  return this.getLighthouseData(flags, config || lhConfig).then(result => {
+    const violations = result.artifacts.Accessibility.violations.filter(
+      violationsFilter
+    );
+
+    return [].concat(
+      ...violations.map(violation => {
+        const {
+          description,
+          nodes,
+          snippet,
+          impact,
+          help,
+          helpUrl,
+          id,
+          tags,
+        } = violation;
+        return nodes.map(node =>
+          Object.assign(
+            {
+              auditId: id,
+              description,
+              snippet,
+              impact,
+              help,
+              helpUrl,
+              tags,
+            },
+            {
+              selector: Array.isArray(node.target) ? node.target.join(' ') : '',
+              path: node.path,
+              snippet: node.snippet,
+            }
+          )
+        );
+      })
+    );
+  });
+};

--- a/test/integration/lighthouse.test.js
+++ b/test/integration/lighthouse.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('assertive');
+const getConfig = require('testium-core').getConfig;
+
+const browser = require('../mini-testium-mocha').browser;
+
+const browserName = getConfig().get('browser');
+
+describe('navigation', () => {
+  if (browserName !== 'chrome') {
+    xit('Skipping lighthouse tests. They only work for chrome.');
+    return;
+  }
+
+  before(browser.beforeHook());
+
+  describe('lighthouse', () => {
+    describe('getLighthouseData', () => {
+      it('can get lighthouse report data', async () => {
+        const results = await browser
+          .navigateTo('/draggable.html')
+          .assertStatusCode(200)
+          .getLighthouseData();
+        const report = results.report;
+        assert.match(/\/draggable\.html$/, JSON.parse(report).finalUrl);
+      });
+    });
+  });
+
+  describe('a11y', () => {
+    it('can audit the accessibility issues', async () => {
+      const results = await browser
+        .navigateTo('/draggable.html')
+        .assertStatusCode(200)
+        .a11yAudit();
+      assert.equal(2, results.length);
+      assert.equal('document-title', results[0].auditId);
+      assert.equal('html-has-lang', results[1].auditId);
+    });
+
+    it('can audit the accessibility issues with ignore array', async () => {
+      const results = await browser
+        .navigateTo('/draggable.html')
+        .assertStatusCode(200)
+        .a11yAudit({ ignore: ['document-title'] });
+      assert.equal(1, results.length);
+      assert.equal('html-has-lang', results[0].auditId);
+    });
+
+    it('can audit the accessibility issues with ignore function', async () => {
+      const results = await browser
+        .navigateTo('/draggable.html')
+        .assertStatusCode(200)
+        .a11yAudit({
+          ignore: violation =>
+            ['document-title', 'html-has-lang'].includes(violation.id),
+        });
+      assert.equal(0, results.length);
+    });
+  });
+});

--- a/test/integration/puppeteer.test.js
+++ b/test/integration/puppeteer.test.js
@@ -3,7 +3,6 @@
 const assert = require('assertive');
 const co = require('co');
 const getConfig = require('testium-core').getConfig;
-const Semver = require('semver');
 
 const browser = require('../mini-testium-mocha').browser;
 
@@ -16,30 +15,6 @@ describe('navigation', () => {
   }
 
   before(browser.beforeHook());
-
-  if (Semver.satisfies(process.version, '>=8.0.0')) {
-    it(
-      'can get lighthouse report data',
-      co.wrap(function*() {
-        yield browser.navigateTo('/draggable.html').assertStatusCode(200);
-        const results = yield browser.getLighthouseData();
-        const report = results.report;
-        assert.match(/\/draggable\.html$/, JSON.parse(report).finalUrl);
-      })
-    );
-  } else {
-    it(
-      'is helpful in the way it reports the lack of lighthouse support',
-      co.wrap(function*() {
-        yield browser.navigateTo('/draggable.html').assertStatusCode(200);
-        const error = yield assert.rejects(browser.getLighthouseData());
-        assert.equal(
-          'Lighthouse requires a newer version of node',
-          error.message
-        );
-      })
-    );
-  }
 
   it(
     'exposes device emulation',


### PR DESCRIPTION
```js
browser.a11yAudit()
browser.a11yAudit({ ignore: ['document-title'], flags, config })
```

returns
```js
[
  {
    "auditId": "document-title",
    "description": "Ensures each HTML document contains a non-empty <title> element",
    "snippet": "<html>",
    "impact": "serious",
    "help": "Documents must have <title> element to aid in navigation",
    "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/document-title?application=axeAPI",
    "tags": ["cat.text-alternatives", "wcag2a", "wcag242"],
    "selector": "html",
    "path": "1,HTML"
  },
  {
    "auditId": "html-has-lang",
    "description": "Ensures every HTML document has a lang attribute",
    "snippet": "<html>",
    "impact": "serious",
    "help": "<html> element must have a lang attribute",
    "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=axeAPI",
    "tags": ["cat.language", "wcag2a", "wcag311"],
    "selector": "html",
    "path": "1,HTML"
  }
]
```