### PR TITLE
feat: browser.getUrlObj()

### DIFF
--- a/lib/browser/navigation.js
+++ b/lib/browser/navigation.js
@@ -33,9 +33,7 @@
 'use strict';
 
 const util = require('util');
-const Url = require('url');
 
-const _ = require('lodash');
 const Asserter = require('wd').Asserter;
 
 const Matchers = require('./_matchers');
@@ -111,10 +109,14 @@ exports.getUrl = function getUrl() {
   return this.url();
 };
 
+exports.getUrlObj = function getUrl() {
+  return this.getUrl().then(url => new URL(url));
+};
+
 exports.getPath = function getPath() {
-  return this.getUrl()
-    .then(Url.parse)
-    .then(_.property('path'));
+  return this.getUrlObj().then(
+    urlObj => `${urlObj.pathname}${urlObj.search}${urlObj.hash}`
+  );
 };
 
 exports.waitForUrl = function waitForUrl(url, query, timeout, pollFreq) {

--- a/test/integration/navigation.test.js
+++ b/test/integration/navigation.test.js
@@ -20,27 +20,27 @@ describe('navigation', () => {
 
   it('supports query args', () =>
     browser
-      .navigateTo('/', { query: { 'a b': 'München', x: 0 } })
-      .assertStatusCode(200)
+      .loadPage('/', { query: { 'a b': 'München', x: 0 } })
       .waitForPath('/?a%20b=M%C3%BCnchen&x=0', 100));
 
   it('with a query string and query arg', () =>
     browser
-      .navigateTo('/?x=0', { query: { 'a b': 'München' } })
-      .assertStatusCode(200)
+      .loadPage('/?x=0', { query: { 'a b': 'München' } })
       .waitForPath('/?x=0&a%20b=M%C3%BCnchen', 100));
 
+  it('with a query string, hash and query arg', () =>
+    browser
+      .loadPage('/?x=0#test', { query: { 'a b': 'München' } })
+      .waitForPath('/?x=0&a%20b=M%C3%BCnchen#test', 100));
+
   it('by clicking a link', async () => {
-    await browser
-      .navigateTo('/')
-      .assertStatusCode(200)
-      .clickOn('.link-to-other-page');
+    await browser.loadPage('/').clickOn('.link-to-other-page');
 
     assert.equal('/other-page.html', await browser.getPath());
   });
 
   it('by refreshing', async () => {
-    await browser.navigateTo('/').assertStatusCode(200);
+    await browser.loadPage('/');
 
     await browser.safeExecute(
       /* eslint-disable no-var, no-undef */
@@ -209,6 +209,14 @@ describe('navigation', () => {
       it('resolves', async () => {
         await browser.loadPage('/').waitForLoadEvent();
       });
+    });
+  });
+
+  describe('getUrlObj', () => {
+    it('returns an instance of URL', async () => {
+      const urlObj = await browser.loadPage('/?x=0').getUrlObj();
+
+      assert.expect(urlObj instanceof URL);
     });
   });
 });


### PR DESCRIPTION
- [x] `getUrlObj` will get the entire URL object
- [x] update `getPath` to use `getUrlObj` internally
- [x] make the url hash part of `getPath`