### PR TITLE
refactor: move promise chain methods according files

### DIFF
--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -35,6 +35,8 @@
 const assert = require('assert');
 const flatMap = require('array.prototype.flatmap');
 
+const lighthouse = require('lighthouse');
+
 /**
  * @typedef import('lighthouse/types/lhr') LH
  */
@@ -203,8 +205,6 @@ function assertScoreByCategory(category, minScore, skipAudits = []) {
   });
 }
 
-exports.assertScoreByCategory = assertScoreByCategory;
-
 /**
  *
  * @param {number} minScore
@@ -220,8 +220,6 @@ function assertPerformanceScore(minScore, skipAudits = []) {
   ]);
 }
 
-exports.assertPerformanceScore = assertPerformanceScore;
-
 /**
  *
  * @param {number} minScore
@@ -231,8 +229,6 @@ exports.assertPerformanceScore = assertPerformanceScore;
 function assertAccessibilityScore(minScore, skipAudits = []) {
   return this.assertScoreByCategory('accessibility', minScore, skipAudits);
 }
-
-exports.assertAccessibilityScore = assertAccessibilityScore;
 
 /**
  *
@@ -244,8 +240,6 @@ function assertBestPracticesScore(minScore, skipAudits = []) {
   return this.assertScoreByCategory('best-practices', minScore, skipAudits);
 }
 
-exports.assertBestPracticesScore = assertBestPracticesScore;
-
 /**
  *
  * @param {number} minScore
@@ -255,8 +249,6 @@ exports.assertBestPracticesScore = assertBestPracticesScore;
 function assertSeoScore(minScore, skipAudits = []) {
   return this.assertScoreByCategory('seo', minScore, skipAudits);
 }
-
-exports.assertSeoScore = assertSeoScore;
 
 /**
  *
@@ -268,8 +260,6 @@ function assertPwaScore(minScore, skipAudits = []) {
   return this.assertScoreByCategory('pwa', minScore, skipAudits);
 }
 
-exports.assertPwaScore = assertPwaScore;
-
 /**
  *
  * @param {?Object} flags
@@ -279,8 +269,6 @@ exports.assertPwaScore = assertPwaScore;
 function runLighthouseAudit(flags, lhConfig) {
   return this.getLighthouseData(flags, lhConfig).then(parseLhResult);
 }
-
-exports.runLighthouseAudit = runLighthouseAudit;
 
 async function a11yAudit(options = {}) {
   const { flags, config, ignore } = options;
@@ -317,5 +305,25 @@ async function a11yAudit(options = {}) {
     }
   );
 }
+async function getLighthouseData(flags, config) {
+  if (!lighthouse) {
+    throw new Error('Lighthouse requires a newer version of node');
+  }
+  const devtoolsPort = await this.getChromeDevtoolsPort();
+  const options = { port: devtoolsPort, ...flags };
+  const url = await this.url();
 
-exports.a11yAudit = a11yAudit;
+  return lighthouse(url, options, config);
+}
+
+module.exports = {
+  a11yAudit,
+  assertAccessibilityScore,
+  assertBestPracticesScore,
+  assertPerformanceScore,
+  assertPwaScore,
+  assertSeoScore,
+  assertScoreByCategory,
+  getLighthouseData,
+  runLighthouseAudit,
+};

--- a/lib/browser/navigation.js
+++ b/lib/browser/navigation.js
@@ -35,8 +35,28 @@
 const util = require('util');
 
 const Asserter = require('wd').Asserter;
+const assert = require('assert');
 
 const Matchers = require('./_matchers');
+
+function assertStatusCode(actual, matcher) {
+  if (typeof matcher === 'number') {
+    assert.strictEqual(
+      actual,
+      matcher,
+      `StatusCode\nExpected: ${matcher}\nActually: ${actual}`
+    );
+  } else if (matcher instanceof RegExp) {
+    assert.ok(
+      matcher.test(`${actual}`),
+      `Pattern ${matcher} doesn't match statusCode\nActually: ${actual}`
+    );
+  } else if (typeof matcher === 'function') {
+    assert.ok(!!matcher(actual), 'StatusCode is as expected');
+  } else {
+    throw new Error(`Invalid expectedStatusCode option: ${actual}`);
+  }
+}
 
 function propertyAsserter(property, expected) {
   const getter = `get${property[0].toUpperCase()}${property.slice(1)}`;
@@ -105,51 +125,81 @@ function waitForDocumentState(self, state, timeout) {
   return self.waitForConditionInBrowser(expr, timeout);
 }
 
-exports.getUrl = function getUrl() {
+function getUrl() {
   return this.url();
-};
+}
 
-exports.getUrlObj = function getUrl() {
+function getUrlObj() {
   return this.getUrl().then(url => new URL(url));
-};
+}
 
-exports.getPath = function getPath() {
+function getPath() {
   return this.getUrlObj().then(
     urlObj => `${urlObj.pathname}${urlObj.search}${urlObj.hash}`
   );
-};
+}
 
-exports.waitForUrl = function waitForUrl(url, query, timeout, pollFreq) {
+function waitForUrl(url, query, timeout, pollFreq) {
   if (typeof query === 'number') {
     timeout = query;
     query = {};
   }
   query = query || {};
   return this.waitFor(urlAsserter(url, query), timeout || 5000, pollFreq);
-};
+}
 
-exports.waitForPath = function waitForPath(path, timeout, pollFreq) {
+function waitForPath(path, timeout, pollFreq) {
   return this.waitFor(
     propertyAsserter('path', path),
     timeout || 5000,
     pollFreq
   );
-};
+}
 
 /**
  * Waits until the document ready state has been reached
  *
  * @param {number} timeout
  */
-exports.waitForDocumentReady = function waitForDocumentReady(timeout) {
+function waitForDocumentReady(timeout) {
   return waitForDocumentState(this, 'interactive', timeout);
-};
+}
 
 /**
  * Waits until the document load state has been reached
  *
  * @param {number} timeout
  */
-exports.waitForLoadEvent = function waitForLoadEvent(timeout) {
+function waitForLoadEvent(timeout) {
   return waitForDocumentState(this, 'complete', timeout);
+}
+
+async function loadPage(url, options) {
+  options = options || {};
+
+  let code = 200;
+  if (options.expectedStatusCode) {
+    code = options.expectedStatusCode;
+    delete options.expectedStatusCode;
+    if (typeof code === 'string') {
+      code = parseInt(code, 10);
+    }
+  }
+
+  const statusCode = await this.navigateTo(url, options).getStatusCode();
+
+  assertStatusCode(statusCode, code);
+
+  return options.waitForLoadEvent !== false ? this.waitForLoadEvent() : this;
+}
+
+module.exports = {
+  getPath,
+  getUrl,
+  getUrlObj,
+  loadPage,
+  waitForDocumentReady,
+  waitForLoadEvent,
+  waitForPath,
+  waitForUrl,
 };

--- a/lib/element.js
+++ b/lib/element.js
@@ -32,29 +32,36 @@
 
 'use strict';
 
-exports.get = function get(name) {
+function get(name) {
   return this.getAttribute(name);
-};
+}
 
 function firstOrNull(elements) {
   return elements[0] || null;
 }
 
-exports.getElementOrNull = function getElementOrNull(selector) {
-  return this.elementsByCssSelector(selector).then(firstOrNull);
-};
+async function getElement(selector) {
+  const elements = await this.elementsByCssSelector(selector);
 
-exports.getElement = function getElement(selector) {
-  return this.elementsByCssSelector(selector).then(elements => {
-    if (elements.length === 0) {
-      throw new Error(
-        `Element ${selector} not found, use getElementOrNull if that's expected`
-      );
-    }
-    return elements[0];
-  });
-};
+  if (elements.length === 0) {
+    throw new Error(
+      `Element ${selector} not found, use getElementOrNull if that's expected`
+    );
+  }
+  return elements[0];
+}
 
-exports.getElements = function getElements(selector) {
+function getElements(selector) {
   return this.elementsByCssSelector(selector);
+}
+
+function getElementOrNull(selector) {
+  return this.elementsByCssSelector(selector).then(firstOrNull);
+}
+
+module.exports = {
+  get,
+  getElement,
+  getElements,
+  getElementOrNull,
 };

--- a/lib/puppeteer.js
+++ b/lib/puppeteer.js
@@ -63,7 +63,7 @@ let puppeteerPageSingleton;
  */
 async function ensurePuppeteerPage(testium) {
   if (!puppeteerPageSingleton) {
-    const port = testium.getChromeDevtoolsPort();
+    const port = await testium.getChromeDevtoolsPort();
     const puppeteerBrowser = await ensurePuppeteerBrowser(port);
     const pages = await puppeteerBrowser.pages();
     // We'll guess and just take the first page.
@@ -89,4 +89,17 @@ function getDevice(deviceDescriptor) {
   return puppeteer.devices[deviceDescriptor];
 }
 
-module.exports = { ensurePuppeteerPage, getDevice };
+function withPuppeteerPage(fn) {
+  return ensurePuppeteerPage(this).then(fn);
+}
+
+function emulate(deviceDescriptor) {
+  return this.withPuppeteerPage(page =>
+    page.emulate(getDevice(deviceDescriptor))
+  );
+}
+
+module.exports = {
+  emulate,
+  withPuppeteerPage,
+};

--- a/lib/testium-driver-wd.js
+++ b/lib/testium-driver-wd.js
@@ -38,9 +38,6 @@ const { v1: uuidV1 } = require('uuid');
 
 const debug = require('debug')('testium-driver-wd');
 const wd = require('wd');
-const assert = require('assert');
-const lighthouse = require('lighthouse');
-const { ensurePuppeteerPage, getDevice } = require('./puppeteer');
 
 wd.Q.longStackSupport = true;
 
@@ -56,12 +53,13 @@ const defaultMethods = [
   require('./browser/page'),
   require('./browser/window'),
   require('./browser/lighthouse'),
+  require('./puppeteer'),
   /* eslint-enable */
 ];
 
 const defaultElementMethods = require('./element');
 
-function applyMethods(methods) {
+function register(methods) {
   for (const [name, fn] of Object.entries(methods)) {
     wd.addPromiseChainMethod(name, fn);
   }
@@ -92,7 +90,7 @@ function applyMixin(mixin) {
   if (!mixins) {
     throw new Error(`couldn't find ${mixin} in ${paths.join(' or ')}`);
   }
-  applyMethods(mixins);
+  register(mixins);
 }
 
 function makeRequestId(currentTest) {
@@ -100,52 +98,21 @@ function makeRequestId(currentTest) {
   return `${currentTest} ${uuidV1()}`.replace(/[^ -~]+/g, '-');
 }
 
-/**
- * @param {string} type
- * @param {any} variable
- * @return {boolean}
- */
-function isType(type, variable) {
-  return (
-    Object.getPrototypeOf(variable).constructor.name.toLowerCase() === type
-  );
-}
-
-function assertStatusCode(actual, matcher) {
-  if (typeof matcher === 'number') {
-    assert.strictEqual(
-      actual,
-      matcher,
-      `StatusCode\nExpected: ${matcher}\nActually: ${actual}`
-    );
-  } else if (matcher instanceof RegExp) {
-    assert.ok(
-      matcher.test(`${actual}`),
-      `Pattern ${matcher} doesn't match statusCode\nActually: ${actual}`
-    );
-  } else if (typeof matcher === 'function') {
-    assert.ok(!!matcher(actual), 'StatusCode is as expected');
-  } else {
-    throw new Error(`Invalid expectedStatusCode option: ${actual}`);
-  }
-}
-
-function initDriver(testium) {
+async function initDriver(testium) {
+  // register non-element methods
   for (const method of defaultMethods) {
-    applyMethods(method);
+    register(method);
   }
 
+  // register mixins
   testium.config.get('mixins.wd', []).forEach(applyMixin);
 
+  // register element methods
   for (const [name, fn] of Object.entries(defaultElementMethods)) {
     wd.addElementPromiseChainMethod(name, fn);
   }
 
   let testiumRootWindow;
-  function storeWindowHandle(handle) {
-    debug('Got root window handle', handle);
-    testiumRootWindow = handle;
-  }
 
   wd.addPromiseChainMethod('navigateTo', function navigateTo(url, options) {
     options = options || {};
@@ -161,24 +128,6 @@ function initDriver(testium) {
     return this.get(targetUrl);
   });
 
-  wd.addPromiseChainMethod('loadPage', function loadPage(url, options) {
-    options = options || {};
-
-    let code = 200;
-    if (options.expectedStatusCode) {
-      code = options.expectedStatusCode;
-      delete options.expectedStatusCode;
-      if (isType('string', code)) code = parseInt(code, 10);
-    }
-
-    const waitForLoadEvent = options.waitForLoadEvent !== false;
-
-    return this.navigateTo(url, options)
-      .getStatusCode()
-      .then(statusCode => assertStatusCode(statusCode, code))
-      .then(() => waitForLoadEvent && this.waitForLoadEvent());
-  });
-
   wd.addPromiseChainMethod(
     'switchToDefaultWindow',
     function switchToDefaultWindow() {
@@ -191,30 +140,6 @@ function initDriver(testium) {
     testium.getChromeDevtoolsPort()
   );
 
-  wd.addPromiseChainMethod('withPuppeteerPage', fn => {
-    return ensurePuppeteerPage(testium).then(fn);
-  });
-
-  wd.addPromiseChainMethod('emulate', deviceDescriptor => {
-    return ensurePuppeteerPage(testium).then(page =>
-      page.emulate(getDevice(deviceDescriptor))
-    );
-  });
-
-  wd.addPromiseChainMethod(
-    'getLighthouseData',
-    function getLighthouseData(flags, config) {
-      if (!lighthouse) {
-        throw new Error('Lighthouse requires a newer version of node');
-      }
-      const devtoolsPort = testium.getChromeDevtoolsPort();
-      const options = { port: devtoolsPort, ...flags };
-      return this.url().then(url => {
-        return lighthouse(url, options, config);
-      });
-    }
-  );
-
   const seleniumUrl = testium.config.get('selenium.serverUrl');
   const driver = wd.remote(seleniumUrl, 'promiseChain');
 
@@ -225,19 +150,19 @@ function initDriver(testium) {
     testium.config.get('proxy.tunnel.host', '127.0.0.1')
   );
 
-  return browser
-    .sessionCapabilities()
-    .then(capabilities => {
-      browser.capabilities = capabilities;
-    })
+  browser.capabilities = await browser.sessionCapabilities();
+
+  await browser
     .windowHandle()
-    .then(storeWindowHandle)
-    .setPageSize({ height: 768, width: 1024 })
-    .get(testium.getInitialUrl())
-    .then(() => {
-      testium.browser = browser;
-      return testium;
-    });
+    .then(handle => {
+      debug('Got root window handle', handle);
+      testiumRootWindow = handle;
+    })
+    .setPageSize({ height: 1000, width: 1400 })
+    .get(testium.getInitialUrl());
+
+  testium.browser = browser;
+  return testium;
 }
 
 module.exports = initDriver;

--- a/package-lock.json
+++ b/package-lock.json
@@ -310,12 +310,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true
-    },
     "@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -479,18 +473,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
-    },
-    "@types/is-windows": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-1.0.0.tgz",
-      "integrity": "sha512-tJ1rq04tGKuIJoWIH0Gyuwv4RQ3+tIu7wQrC0MV47raQ44kIzXSSFKfrxFUOWVRvesoF7mrTqigXmqoZJsXwTg==",
-      "dev": true
-    },
-    "@types/istanbul-lib-coverage": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
       "dev": true
     },
     "@types/json5": {
@@ -747,9 +729,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",
+          "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw=="
         }
       }
     },
@@ -1131,13 +1113,20 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.1.tgz",
-      "integrity": "sha512-FL/TdvchukRCuWVxT0YMO/7+L5TNeNrVFvRU2IY63aUyv9mpt8splf2NEr6qXtPo5fya5a66YohQKvGNmLrWNA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
+      "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
       "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       },
       "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -1280,162 +1269,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "c8": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.4.0.tgz",
-      "integrity": "sha512-K8I7MEe2i4L91YBX3HtV10kKpU5uqGeyjtsdGS2FxfT0pk15d9jthujjR1ORRLrCJ4tXuDK9PSH2vChzRDoAZw==",
-      "dev": true,
-      "requires": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@istanbuljs/schema": "^0.1.2",
-        "find-up": "^5.0.0",
-        "foreground-child": "^2.0.0",
-        "furi": "^2.0.0",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-reports": "^3.0.2",
-        "rimraf": "^3.0.0",
-        "test-exclude": "^6.0.0",
-        "v8-to-istanbul": "^7.1.0",
-        "yargs": "^16.0.0",
-        "yargs-parser": "^20.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-          "dev": true
-        }
-      }
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -2159,14 +1992,6 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-          "dev": true
-        }
       }
     },
     "error-ex": {
@@ -2209,12 +2034,6 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
-    },
     "escape-goat": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
@@ -2226,9 +2045,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.18.0.tgz",
-      "integrity": "sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.19.0.tgz",
+      "integrity": "sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2585,9 +2404,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -3034,16 +2853,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "furi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/furi/-/furi-2.0.0.tgz",
-      "integrity": "sha512-uKuNsaU0WVaK/vmvj23wW1bicOFfyqSsAIH71bRZx8kA4Xj+YCHin7CJKJJjkIsmxYaPFLk9ljmjEyB7xF7WvQ==",
-      "dev": true,
-      "requires": {
-        "@types/is-windows": "^1.0.0",
-        "is-windows": "^1.0.2"
-      }
     },
     "gensync": {
       "version": "1.0.0-beta.1",
@@ -6773,9 +6582,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
-          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
+          "integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -7244,25 +7053,6 @@
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
-    "v8-to-istanbul": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz",
-      "integrity": "sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -7298,9 +7088,9 @@
       }
     },
     "wd": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-1.13.0.tgz",
-      "integrity": "sha512-Y73EADwIrz1AAmy5G70r/fIM2tzSTdLWjIgCqGlQOr2/k2cC2nho4kWacZdO3xmdsegeQvUkcsGOB74+gC9Wxg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.14.0.tgz",
+      "integrity": "sha512-X7ZfGHHYlQ5zYpRlgP16LUsvYti+Al/6fz3T/ClVyivVCpCZQpESTDdz6zbK910O5OIvujO23Ym2DBBo3XsQlA==",
       "requires": {
         "archiver": "^3.0.0",
         "async": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "puppeteer-core": "^3.3.0",
     "testium-cookie": "^2.0.1",
     "uuid": "^8.3.2",
-    "wd": "^1.13.0"
+    "wd": "^1.14.0"
   },
   "devDependencies": {
     "chromedriver": "^88.0.0",
-    "eslint": "^7.18.0",
+    "eslint": "^7.19.0",
     "eslint-config-groupon": "^10.0.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-mocha": "^8.0.0",


### PR DESCRIPTION
By moving functions into according files, it will become much easier in the future to extract lighthouse / puppeteer into their own testium mixin for the next major

- [x] refactor: move promise chain methods according files
- [x] chore: update dependencies
