### PR TITLE
Lighthouse audit details fix

### DIFF
--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -138,7 +138,7 @@ function parseLhResult(results) {
       notApplicableObj[id] = auditInfo;
     } else if (scoreDisplayMode !== 'manual') {
       const snippets = [];
-      if (details && details.items.length) {
+      if (details && details.items && details.items.length) {
         details.items.forEach(item =>
           snippets.push((item.node && item.node.snippet) || '')
         );

--- a/lib/browser/lighthouse.js
+++ b/lib/browser/lighthouse.js
@@ -138,8 +138,7 @@ function parseLhResult(results) {
       notApplicableObj[id] = auditInfo;
     } else if (scoreDisplayMode !== 'manual') {
       const snippets = [];
-      if (details && details.items && details.items.length) {
-        details.items.forEach(item =>
+      (details && details.items || []).forEach(item =>
           snippets.push((item.node && item.node.snippet) || '')
         );
       }


### PR DESCRIPTION
Some of lighthouse's audits have details, but not a details.items, so when the previous line would check for details.items.length it would automatically fail, making browser.runLighthouseAudit unusable.